### PR TITLE
Use enums/booleans for enumerated attributes.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -32,6 +32,9 @@
   </path>
 
   <path id="test.classpath">
+    <fileset dir="${third_party.dir}">
+        <include name="guava/*.jar"/>
+    </fileset>
     <fileset dir="third_party/junit">
       <include name="junit-4.11.jar"/>
       <include name="hamcrest-core-1.3.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -32,9 +32,6 @@
   </path>
 
   <path id="test.classpath">
-    <fileset dir="${third_party.dir}">
-        <include name="guava/*.jar"/>
-    </fileset>
     <fileset dir="third_party/junit">
       <include name="junit-4.11.jar"/>
       <include name="hamcrest-core-1.3.jar"/>

--- a/src/com/google/enterprise/gsafeed/Acl.java
+++ b/src/com/google/enterprise/gsafeed/Acl.java
@@ -71,6 +71,9 @@ public class Acl {
     }
 
     public static InheritanceType fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (InheritanceType inheritanceType : InheritanceType.values()) {
         if (inheritanceType.xmlValue.equals(value)) {
           return inheritanceType;

--- a/src/com/google/enterprise/gsafeed/Acl.java
+++ b/src/com/google/enterprise/gsafeed/Acl.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed;
 
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -47,6 +48,41 @@ public class Acl {
   protected String inheritFrom;
   protected List<Principal> principal;
 
+  /** Inheritance types. */
+  public static enum InheritanceType {
+    CHILD_OVERRIDES("child-overrides"),
+    PARENT_OVERRIDES("parent-overrides"),
+    AND_BOTH_PERMIT("and-both-permit"),
+    LEAF_NODE("leaf-node");
+
+    private String xmlValue;
+
+    private InheritanceType(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static InheritanceType fromString(String value) {
+      if (value.equals("child-overrides")) {
+        return CHILD_OVERRIDES;
+      }
+      if (value.equals("parent-overrides")) {
+          return PARENT_OVERRIDES;
+      }
+      if (value.equals("and-both-permit")) {
+        return AND_BOTH_PERMIT;
+      }
+      if (value.equals("leaf-node")) {
+        return LEAF_NODE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the url property.
    *
@@ -70,24 +106,45 @@ public class Acl {
   /**
    * Gets the value of the inheritanceType property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link InheritanceType}
    */
-  public String getInheritanceType() {
+  public InheritanceType getInheritanceType() {
     if (inheritanceType == null) {
-      return "leaf-node";
+      return null;
     } else {
-      return inheritanceType;
+      return InheritanceType.fromString(inheritanceType);
     }
   }
 
   /**
    * Sets the value of the inheritanceType property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * inheritance-type attribute value
    */
   public Acl setInheritanceType(String value) {
-    this.inheritanceType = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.inheritanceType = null;
+    } else {
+      setInheritanceType(InheritanceType.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the inheritanceType property.
+   *
+   * @param value allowed object is {@link InheritanceType} or null
+   * @return this object
+   */
+  public Acl setInheritanceType(InheritanceType value) {
+    if (value == null) {
+      this.inheritanceType = null;
+    } else {
+      this.inheritanceType = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Acl.java
+++ b/src/com/google/enterprise/gsafeed/Acl.java
@@ -14,18 +14,18 @@
 
 package com.google.enterprise.gsafeed;
 
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -41,18 +41,22 @@ public class Acl {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String url;
   @XmlAttribute(name = "inheritance-type")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String inheritanceType;
+  protected InheritanceType inheritanceType;
   @XmlAttribute(name = "inherit-from")
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String inheritFrom;
   protected List<Principal> principal;
 
   /** Inheritance types. */
+  @XmlEnum(String.class)
   public static enum InheritanceType {
+    @XmlEnumValue("child-overrides")
     CHILD_OVERRIDES("child-overrides"),
+    @XmlEnumValue("parent-overrides")
     PARENT_OVERRIDES("parent-overrides"),
+    @XmlEnumValue("and-both-permit")
     AND_BOTH_PERMIT("and-both-permit"),
+    @XmlEnumValue("leaf-node")
     LEAF_NODE("leaf-node");
 
     private String xmlValue;
@@ -67,17 +71,10 @@ public class Acl {
     }
 
     public static InheritanceType fromString(String value) {
-      if (value.equals("child-overrides")) {
-        return CHILD_OVERRIDES;
-      }
-      if (value.equals("parent-overrides")) {
-          return PARENT_OVERRIDES;
-      }
-      if (value.equals("and-both-permit")) {
-        return AND_BOTH_PERMIT;
-      }
-      if (value.equals("leaf-node")) {
-        return LEAF_NODE;
+      for (InheritanceType inheritanceType : InheritanceType.values()) {
+        if (inheritanceType.xmlValue.equals(value)) {
+          return inheritanceType;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -109,28 +106,7 @@ public class Acl {
    * @return possible object is {@link InheritanceType}
    */
   public InheritanceType getInheritanceType() {
-    if (inheritanceType == null) {
-      return null;
-    } else {
-      return InheritanceType.fromString(inheritanceType);
-    }
-  }
-
-  /**
-   * Sets the value of the inheritanceType property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * inheritance-type attribute value
-   */
-  public Acl setInheritanceType(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.inheritanceType = null;
-    } else {
-      setInheritanceType(InheritanceType.fromString(value));
-    }
-    return this;
+    return inheritanceType;
   }
 
   /**
@@ -140,11 +116,7 @@ public class Acl {
    * @return this object
    */
   public Acl setInheritanceType(InheritanceType value) {
-    if (value == null) {
-      this.inheritanceType = null;
-    } else {
-      this.inheritanceType = value.toString();
-    }
+    this.inheritanceType = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Content.java
+++ b/src/com/google/enterprise/gsafeed/Content.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed;
 
+import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -40,23 +41,74 @@ public class Content {
   @XmlValue
   protected String value;
 
+  /** Encoding types. */
+  public static enum Encoding {
+    BASE_64_BINARY("base64binary"),
+    BASE_64_COMPRESSED("base64compressed");
+
+    private String xmlValue;
+
+    private Encoding(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Encoding fromString(String value) {
+      if (value.equals("base64binary")) {
+        return BASE_64_BINARY;
+      }
+      if (value.equals("base64compressed")) {
+          return BASE_64_COMPRESSED;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the encoding property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Encoding}
    */
-  public String getEncoding() {
-    return encoding;
+  public Encoding getEncoding() {
+    if (encoding == null) {
+      return null;
+    }
+    return Encoding.fromString(encoding);
   }
 
   /**
    * Sets the value of the encoding property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * encoding attribute value
    */
   public Content setEncoding(String value) {
-    this.encoding = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.encoding = null;
+    } else {
+      setEncoding(Encoding.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the encoding property.
+   *
+   * @param value allowed object is {@link String} or null
+   * @return this object
+   */
+  public Content setEncoding(Encoding value) {
+    if (value == null) {
+      this.encoding = null;
+    } else {
+      this.encoding = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Content.java
+++ b/src/com/google/enterprise/gsafeed/Content.java
@@ -59,6 +59,9 @@ public class Content {
     }
 
     public static Encoding fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Encoding encoding : Encoding.values()) {
         if (encoding.xmlValue.equals(value)) {
           return encoding;

--- a/src/com/google/enterprise/gsafeed/Content.java
+++ b/src/com/google/enterprise/gsafeed/Content.java
@@ -43,9 +43,9 @@ public class Content {
   @XmlEnum(String.class)
   public static enum Encoding {
     @XmlEnumValue("base64binary")
-    BASE_64_BINARY("base64binary"),
+    BASE64_BINARY("base64binary"),
     @XmlEnumValue("base64compressed")
-    BASE_64_COMPRESSED("base64compressed");
+    BASE64_COMPRESSED("base64compressed");
 
     private String xmlValue;
 

--- a/src/com/google/enterprise/gsafeed/Content.java
+++ b/src/com/google/enterprise/gsafeed/Content.java
@@ -14,16 +14,14 @@
 
 package com.google.enterprise.gsafeed;
 
-import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -36,14 +34,17 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Content {
 
   @XmlAttribute(name = "encoding")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String encoding;
+  protected Encoding encoding;
   @XmlValue
   protected String value;
 
   /** Encoding types. */
+  @XmlType(name = "content-encoding")
+  @XmlEnum(String.class)
   public static enum Encoding {
+    @XmlEnumValue("base64binary")
     BASE_64_BINARY("base64binary"),
+    @XmlEnumValue("base64compressed")
     BASE_64_COMPRESSED("base64compressed");
 
     private String xmlValue;
@@ -58,11 +59,10 @@ public class Content {
     }
 
     public static Encoding fromString(String value) {
-      if (value.equals("base64binary")) {
-        return BASE_64_BINARY;
-      }
-      if (value.equals("base64compressed")) {
-          return BASE_64_COMPRESSED;
+      for (Encoding encoding : Encoding.values()) {
+        if (encoding.xmlValue.equals(value)) {
+          return encoding;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -74,27 +74,7 @@ public class Content {
    * @return possible object is {@link Encoding}
    */
   public Encoding getEncoding() {
-    if (encoding == null) {
-      return null;
-    }
-    return Encoding.fromString(encoding);
-  }
-
-  /**
-   * Sets the value of the encoding property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * encoding attribute value
-   */
-  public Content setEncoding(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.encoding = null;
-    } else {
-      setEncoding(Encoding.fromString(value));
-    }
-    return this;
+    return encoding;
   }
 
   /**
@@ -104,11 +84,7 @@ public class Content {
    * @return this object
    */
   public Content setEncoding(Encoding value) {
-    if (value == null) {
-      this.encoding = null;
-    } else {
-      this.encoding = value.toString();
-    }
+    this.encoding = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Group.java
+++ b/src/com/google/enterprise/gsafeed/Group.java
@@ -16,17 +16,18 @@ package com.google.enterprise.gsafeed;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -39,8 +40,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Group {
 
   @XmlAttribute(name = "action")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String action;
+  protected Action action;
   @XmlAttribute(name = "feedrank")
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String feedrank;
@@ -54,8 +54,12 @@ public class Group {
   protected List<Object> aclOrRecord;
 
   /** Action types. */
+  @XmlType(name = "group-action")
+  @XmlEnum(String.class)
   public static enum Action {
+    @XmlEnumValue("add")
     ADD("add"),
+    @XmlEnumValue("delete")
     DELETE("delete");
 
     private String xmlValue;
@@ -70,11 +74,10 @@ public class Group {
     }
 
     public static Action fromString(String value) {
-      if (value.equals("add")) {
-        return ADD;
-      }
-      if (value.equals("delete")) {
-          return DELETE;
+      for (Action action : Action.values()) {
+        if (action.xmlValue.equals(value)) {
+          return action;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -86,28 +89,7 @@ public class Group {
    * @return possible object is {@link Action}
    */
   public Action getAction() {
-    if (action == null) {
-      return null;
-    } else {
-      return Action.fromString(action);
-    }
-  }
-
-  /**
-   * Sets the value of the action property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * action attribute value
-   */
-  public Group setAction(String value) {
-    if (value == null) {
-      this.action = null;
-    } else {
-      setAction(Action.fromString(value));
-    }
-    return this;
+    return action;
   }
 
   /**
@@ -117,11 +99,7 @@ public class Group {
    * @return this object
    */
   public Group setAction(Action value) {
-    if (value == null) {
-      this.action = null;
-    } else {
-      this.action = value.toString();
-    }
+    this.action = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Group.java
+++ b/src/com/google/enterprise/gsafeed/Group.java
@@ -53,27 +53,75 @@ public class Group {
   })
   protected List<Object> aclOrRecord;
 
+  /** Action types. */
+  public static enum Action {
+    ADD("add"),
+    DELETE("delete");
+
+    private String xmlValue;
+
+    private Action(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Action fromString(String value) {
+      if (value.equals("add")) {
+        return ADD;
+      }
+      if (value.equals("delete")) {
+          return DELETE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the action property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Action}
    */
-  public String getAction() {
+  public Action getAction() {
     if (action == null) {
-      return "add";
+      return null;
     } else {
-      return action;
+      return Action.fromString(action);
     }
   }
 
   /**
    * Sets the value of the action property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * action attribute value
    */
   public Group setAction(String value) {
-    this.action = value;
+    if (value == null) {
+      this.action = null;
+    } else {
+      setAction(Action.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the action property.
+   *
+   * @param value allowed object is {@link Action} or null
+   * @return this object
+   */
+  public Group setAction(Action value) {
+    if (value == null) {
+      this.action = null;
+    } else {
+      this.action = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Group.java
+++ b/src/com/google/enterprise/gsafeed/Group.java
@@ -74,6 +74,9 @@ public class Group {
     }
 
     public static Action fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Action action : Action.values()) {
         if (action.xmlValue.equals(value)) {
           return action;

--- a/src/com/google/enterprise/gsafeed/GsafeedHelper.java
+++ b/src/com/google/enterprise/gsafeed/GsafeedHelper.java
@@ -17,10 +17,12 @@ package com.google.enterprise.gsafeed;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -28,6 +30,7 @@ import javax.xml.parsers.ParserConfigurationException;
  * Helper for reading and creating GSA feed files.
  */
 public class GsafeedHelper extends FeedHelper {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   public GsafeedHelper() throws JAXBException {
     super(Gsafeed.class, "gsafeed", "/gsafeed.dtd");
@@ -55,6 +58,16 @@ public class GsafeedHelper extends FeedHelper {
   }
 
   /**
+   * Use the DTD to check for errors in the feed being read. The
+   * xml is assumed to be UTF-8.
+   */
+  public Gsafeed unmarshalWithDtd(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
+    return unmarshalWithDtd(new ByteArrayInputStream(xml.getBytes(UTF_8)));
+  }
+
+  /**
    * Avoid reading the DTD. No validation will happen.
    */
   public Gsafeed unmarshalWithoutDtd(URL url) throws JAXBException,
@@ -69,6 +82,16 @@ public class GsafeedHelper extends FeedHelper {
       throws JAXBException, IOException, ParserConfigurationException,
       SAXException {
     return (Gsafeed) unmarshal(inputStream, Validation.FALSE);
+  }
+
+  /**
+   * Avoid reading the DTD. No validation will happen. The xml is
+   * assumed to be UTF-8.
+   */
+  public Gsafeed unmarshalWithoutDtd(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
+    return unmarshalWithoutDtd(new ByteArrayInputStream(xml.getBytes(UTF_8)));
   }
 
   /**

--- a/src/com/google/enterprise/gsafeed/Meta.java
+++ b/src/com/google/enterprise/gsafeed/Meta.java
@@ -14,16 +14,15 @@
 
 package com.google.enterprise.gsafeed;
 
-import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -34,8 +33,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Meta {
 
   @XmlAttribute(name = "encoding")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String encoding;
+  protected Encoding encoding;
   @XmlAttribute(name = "name", required = true)
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String name;
@@ -44,7 +42,10 @@ public class Meta {
   protected String content;
 
   /** Encoding types. */
+  @XmlType(name = "meta-encoding")
+  @XmlEnum(String.class)
   public static enum Encoding {
+    @XmlEnumValue("base64binary")
     BASE_64_BINARY("base64binary");
 
     private String xmlValue;
@@ -59,8 +60,10 @@ public class Meta {
     }
 
     public static Encoding fromString(String value) {
-      if (value.equals("base64binary")) {
-        return BASE_64_BINARY;
+      for (Encoding encoding : Encoding.values()) {
+        if (encoding.xmlValue.equals(value)) {
+          return encoding;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -72,27 +75,7 @@ public class Meta {
    * @return possible object is {@link Encoding}
    */
   public Encoding getEncoding() {
-    if (encoding == null) {
-      return null;
-    }
-    return Encoding.fromString(encoding);
-  }
-
-  /**
-   * Sets the value of the encoding property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * encoding attribute value
-   */
-  public Meta setEncoding(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.encoding = null;
-    } else {
-      setEncoding(Encoding.fromString(value));
-    }
-    return this;
+    return encoding;
   }
 
   /**
@@ -102,11 +85,7 @@ public class Meta {
    * @return this object
    */
   public Meta setEncoding(Encoding value) {
-    if (value == null) {
-      this.encoding = null;
-    } else {
-      this.encoding = value.toString();
-    }
+    this.encoding = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Meta.java
+++ b/src/com/google/enterprise/gsafeed/Meta.java
@@ -60,6 +60,9 @@ public class Meta {
     }
 
     public static Encoding fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Encoding encoding : Encoding.values()) {
         if (encoding.xmlValue.equals(value)) {
           return encoding;

--- a/src/com/google/enterprise/gsafeed/Meta.java
+++ b/src/com/google/enterprise/gsafeed/Meta.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed;
 
+import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -42,23 +43,70 @@ public class Meta {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String content;
 
+  /** Encoding types. */
+  public static enum Encoding {
+    BASE_64_BINARY("base64binary");
+
+    private String xmlValue;
+
+    private Encoding(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Encoding fromString(String value) {
+      if (value.equals("base64binary")) {
+        return BASE_64_BINARY;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the encoding property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Encoding}
    */
-  public String getEncoding() {
-    return encoding;
+  public Encoding getEncoding() {
+    if (encoding == null) {
+      return null;
+    }
+    return Encoding.fromString(encoding);
   }
 
   /**
    * Sets the value of the encoding property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * encoding attribute value
    */
   public Meta setEncoding(String value) {
-    this.encoding = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.encoding = null;
+    } else {
+      setEncoding(Encoding.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the encoding property.
+   *
+   * @param value allowed object is {@link Encoding} or null
+   * @return this object
+   */
+  public Meta setEncoding(Encoding value) {
+    if (value == null) {
+      this.encoding = null;
+    } else {
+      this.encoding = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Meta.java
+++ b/src/com/google/enterprise/gsafeed/Meta.java
@@ -46,7 +46,7 @@ public class Meta {
   @XmlEnum(String.class)
   public static enum Encoding {
     @XmlEnumValue("base64binary")
-    BASE_64_BINARY("base64binary");
+    BASE64_BINARY("base64binary");
 
     private String xmlValue;
 

--- a/src/com/google/enterprise/gsafeed/Metadata.java
+++ b/src/com/google/enterprise/gsafeed/Metadata.java
@@ -43,14 +43,16 @@ public class Metadata {
   /**
    * Gets the value of the overwriteAcls property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link boolean}
    */
-  public String getOverwriteAcls() {
+  public boolean getOverwriteAcls() {
+    // The default as defined in the dtd is true. Return that
+    // here to reflect the underlying meaning, but don't set the
+    // string to avoid adding the attribute to the generated xml.
     if (overwriteAcls == null) {
-      return "true";
-    } else {
-      return overwriteAcls;
+      return true;
     }
+    return Boolean.valueOf(overwriteAcls);
   }
 
   /**
@@ -60,7 +62,18 @@ public class Metadata {
    * @return this object
    */
   public Metadata setOverwriteAcls(String value) {
-    this.overwriteAcls = value;
+    this.overwriteAcls = Boolean.valueOf(value).toString();
+    return this;
+  }
+
+  /**
+   * Sets the value of the overwriteAcls property.
+   *
+   * @param value allowed object is {@link boolean}
+   * @return this object
+   */
+  public Metadata setOverwriteAcls(boolean value) {
+    this.overwriteAcls = Boolean.toString(value);
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Metadata.java
+++ b/src/com/google/enterprise/gsafeed/Metadata.java
@@ -16,14 +16,12 @@ package com.google.enterprise.gsafeed;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -36,44 +34,26 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Metadata {
 
   @XmlAttribute(name = "overwrite-acls")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String overwriteAcls;
+  protected Boolean overwriteAcls;
   protected List<Meta> meta;
 
   /**
    * Gets the value of the overwriteAcls property.
    *
-   * @return possible object is {@link boolean}
+   * @return possible object is {@link Boolean}
    */
-  public boolean getOverwriteAcls() {
-    // The default as defined in the dtd is true. Return that
-    // here to reflect the underlying meaning, but don't set the
-    // string to avoid adding the attribute to the generated xml.
-    if (overwriteAcls == null) {
-      return true;
-    }
-    return Boolean.valueOf(overwriteAcls);
+  public Boolean getOverwriteAcls() {
+    return overwriteAcls;
   }
 
   /**
    * Sets the value of the overwriteAcls property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Boolean} or null
    * @return this object
    */
-  public Metadata setOverwriteAcls(String value) {
-    this.overwriteAcls = Boolean.valueOf(value).toString();
-    return this;
-  }
-
-  /**
-   * Sets the value of the overwriteAcls property.
-   *
-   * @param value allowed object is {@link boolean}
-   * @return this object
-   */
-  public Metadata setOverwriteAcls(boolean value) {
-    this.overwriteAcls = Boolean.toString(value);
+  public Metadata setOverwriteAcls(Boolean value) {
+    this.overwriteAcls = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Principal.java
+++ b/src/com/google/enterprise/gsafeed/Principal.java
@@ -14,17 +14,16 @@
 
 package com.google.enterprise.gsafeed;
 
-import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -37,26 +36,25 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Principal {
 
   @XmlAttribute(name = "scope", required = true)
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String scope;
+  protected Scope scope;
   @XmlAttribute(name = "access", required = true)
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String access;
+  protected Access access;
   @XmlAttribute(name = "namespace")
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String namespace;
   @XmlAttribute(name = "case-sensitivity-type")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String caseSensitivityType;
+  protected CaseSensitivityType caseSensitivityType;
   @XmlAttribute(name = "principal-type")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String principalType;
+  protected PrincipalType principalType;
   @XmlValue
   protected String value;
 
   /** Scopes. */
+  @XmlEnum(String.class)
   public static enum Scope {
+    @XmlEnumValue("user")
     USER("user"),
+    @XmlEnumValue("group")
     GROUP("group");
 
     private String xmlValue;
@@ -71,19 +69,21 @@ public class Principal {
     }
 
     public static Scope fromString(String value) {
-      if (value.equals("user")) {
-        return USER;
-      }
-      if (value.equals("group")) {
-        return GROUP;
+      for (Scope scope : Scope.values()) {
+        if (scope.xmlValue.equals(value)) {
+          return scope;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   }
 
   /** Access values. */
+  @XmlEnum(String.class)
   public static enum Access {
+    @XmlEnumValue("permit")
     PERMIT("permit"),
+    @XmlEnumValue("deny")
     DENY("deny");
 
     private String xmlValue;
@@ -98,19 +98,21 @@ public class Principal {
     }
 
     public static Access fromString(String value) {
-      if (value.equals("permit")) {
-        return PERMIT;
-      }
-      if (value.equals("deny")) {
-        return DENY;
+      for (Access access : Access.values()) {
+        if (access.xmlValue.equals(value)) {
+          return access;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   }
 
   /** Case sensitivity. */
+  @XmlEnum(String.class)
   public static enum CaseSensitivityType {
+    @XmlEnumValue("everything-case-sensitive")
     EVERYTHING_CASE_SENSITIVE("everything-case-sensitive"),
+    @XmlEnumValue("everything-case-insensitive")
     EVERYTHING_CASE_INSENSITIVE("everything-case-insensitive");
 
     private String xmlValue;
@@ -125,18 +127,19 @@ public class Principal {
     }
 
     public static CaseSensitivityType fromString(String value) {
-      if (value.equals("everything-case-sensitive")) {
-        return EVERYTHING_CASE_SENSITIVE;
-      }
-      if (value.equals("everything-case-insensitive")) {
-        return EVERYTHING_CASE_INSENSITIVE;
+      for (CaseSensitivityType type : CaseSensitivityType.values()) {
+        if (type.xmlValue.equals(value)) {
+          return type;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   }
 
   /** Principal type. */
+  @XmlEnum(String.class)
   public static enum PrincipalType {
+    @XmlEnumValue("unqualified")
     UNQUALIFIED("unqualified");
 
     private String xmlValue;
@@ -151,8 +154,10 @@ public class Principal {
     }
 
     public static PrincipalType fromString(String value) {
-      if (value.equals("unqualified")) {
-        return UNQUALIFIED;
+      for (PrincipalType type : PrincipalType.values()) {
+        if (type.xmlValue.equals(value)) {
+          return type;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -164,20 +169,7 @@ public class Principal {
    * @return possible object is {@link Scope}
    */
   public Scope getScope() {
-    return Scope.fromString(scope);
-  }
-
-  /**
-   * Sets the value of the scope property.
-   *
-   * @param value allowed object is {@link String}
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * scope attribute value
-   */
-  public Principal setScope(String value) {
-    // scope is required, so don't accept null
-    return setScope(Scope.fromString(value));
+    return scope;
   }
 
   /**
@@ -187,8 +179,10 @@ public class Principal {
    * @return this object
    */
   public Principal setScope(Scope value) {
-    // scope is required, so don't accept null
-    this.scope = value.toString();
+    if (value == null) {
+      throw new IllegalArgumentException("null");
+    }
+    this.scope = value;
     return this;
   }
 
@@ -198,22 +192,20 @@ public class Principal {
    * @return possible object is {@link String}
    */
   public Access getAccess() {
-    return Access.fromString(access);
+    return access;
   }
 
   /**
    * Sets the value of the access property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Access}
    * @return this object
    */
-  public Principal setAccess(String value) {
-    // access is required, so don't accept null
-    return setAccess(Access.fromString(value));
-  }
-
   public Principal setAccess(Access value) {
-    this.access = value.toString();
+    if (value == null) {
+      throw new IllegalArgumentException("null");
+    }
+    this.access = value;
     return this;
   }
 
@@ -247,28 +239,7 @@ public class Principal {
    * @return possible object is {@link CaseSensitivityType}
    */
   public CaseSensitivityType getCaseSensitivityType() {
-    if (caseSensitivityType == null) {
-      return null;
-    } else {
-      return CaseSensitivityType.fromString(caseSensitivityType);
-    }
-  }
-
-  /**
-   * Sets the value of the caseSensitivityType property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * case-sensitivity-type attribute value
-   */
-  public Principal setCaseSensitivityType(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.caseSensitivityType = null;
-    } else {
-      setCaseSensitivityType(CaseSensitivityType.fromString(value));
-    }
-    return this;
+    return caseSensitivityType;
   }
 
   /**
@@ -278,11 +249,7 @@ public class Principal {
    * @return this object
    */
   public Principal setCaseSensitivityType(CaseSensitivityType value) {
-    if (value == null) {
-      this.caseSensitivityType = null;
-    } else {
-      this.caseSensitivityType = value.toString();
-    }
+    this.caseSensitivityType = value;
     return this;
   }
 
@@ -292,27 +259,7 @@ public class Principal {
    * @return possible object is {@link PrincipalType}
    */
   public PrincipalType getPrincipalType() {
-    if (principalType == null) {
-      return null;
-    }
-    return PrincipalType.fromString(this.principalType);
-  }
-
-  /**
-   * Sets the value of the principalType property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * principal-type attribute value
-   */
-  public Principal setPrincipalType(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.principalType = null;
-    } else {
-      setPrincipalType(PrincipalType.fromString(value));
-    }
-    return this;
+    return principalType;
   }
 
   /**
@@ -322,11 +269,7 @@ public class Principal {
    * @return this object
    */
   public Principal setPrincipalType(PrincipalType value) {
-    if (value == null) {
-      this.principalType = null;
-    } else {
-      this.principalType = value.toString();
-    }
+    this.principalType = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Principal.java
+++ b/src/com/google/enterprise/gsafeed/Principal.java
@@ -69,6 +69,9 @@ public class Principal {
     }
 
     public static Scope fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Scope scope : Scope.values()) {
         if (scope.xmlValue.equals(value)) {
           return scope;
@@ -98,6 +101,9 @@ public class Principal {
     }
 
     public static Access fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Access access : Access.values()) {
         if (access.xmlValue.equals(value)) {
           return access;
@@ -127,6 +133,9 @@ public class Principal {
     }
 
     public static CaseSensitivityType fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (CaseSensitivityType type : CaseSensitivityType.values()) {
         if (type.xmlValue.equals(value)) {
           return type;
@@ -154,6 +163,9 @@ public class Principal {
     }
 
     public static PrincipalType fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (PrincipalType type : PrincipalType.values()) {
         if (type.xmlValue.equals(value)) {
           return type;

--- a/src/com/google/enterprise/gsafeed/Principal.java
+++ b/src/com/google/enterprise/gsafeed/Principal.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed;
 
+import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -53,13 +54,117 @@ public class Principal {
   @XmlValue
   protected String value;
 
+  /** Scopes. */
+  public static enum Scope {
+    USER("user"),
+    GROUP("group");
+
+    private String xmlValue;
+
+    private Scope(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Scope fromString(String value) {
+      if (value.equals("user")) {
+        return USER;
+      }
+      if (value.equals("group")) {
+        return GROUP;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Access values. */
+  public static enum Access {
+    PERMIT("permit"),
+    DENY("deny");
+
+    private String xmlValue;
+
+    private Access(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Access fromString(String value) {
+      if (value.equals("permit")) {
+        return PERMIT;
+      }
+      if (value.equals("deny")) {
+        return DENY;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Case sensitivity. */
+  public static enum CaseSensitivityType {
+    EVERYTHING_CASE_SENSITIVE("everything-case-sensitive"),
+    EVERYTHING_CASE_INSENSITIVE("everything-case-insensitive");
+
+    private String xmlValue;
+
+    private CaseSensitivityType(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static CaseSensitivityType fromString(String value) {
+      if (value.equals("everything-case-sensitive")) {
+        return EVERYTHING_CASE_SENSITIVE;
+      }
+      if (value.equals("everything-case-insensitive")) {
+        return EVERYTHING_CASE_INSENSITIVE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Principal type. */
+  public static enum PrincipalType {
+    UNQUALIFIED("unqualified");
+
+    private String xmlValue;
+
+    private PrincipalType(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static PrincipalType fromString(String value) {
+      if (value.equals("unqualified")) {
+        return UNQUALIFIED;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the scope property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Scope}
    */
-  public String getScope() {
-    return scope;
+  public Scope getScope() {
+    return Scope.fromString(scope);
   }
 
   /**
@@ -67,9 +172,23 @@ public class Principal {
    *
    * @param value allowed object is {@link String}
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * scope attribute value
    */
   public Principal setScope(String value) {
-    this.scope = value;
+    // scope is required, so don't accept null
+    return setScope(Scope.fromString(value));
+  }
+
+  /**
+   * Sets the value of the scope property.
+   *
+   * @param value allowed object is {@link Scope}
+   * @return this object
+   */
+  public Principal setScope(Scope value) {
+    // scope is required, so don't accept null
+    this.scope = value.toString();
     return this;
   }
 
@@ -78,8 +197,8 @@ public class Principal {
    *
    * @return possible object is {@link String}
    */
-  public String getAccess() {
-    return access;
+  public Access getAccess() {
+    return Access.fromString(access);
   }
 
   /**
@@ -89,7 +208,12 @@ public class Principal {
    * @return this object
    */
   public Principal setAccess(String value) {
-    this.access = value;
+    // access is required, so don't accept null
+    return setAccess(Access.fromString(value));
+  }
+
+  public Principal setAccess(Access value) {
+    this.access = value.toString();
     return this;
   }
 
@@ -120,44 +244,89 @@ public class Principal {
   /**
    * Gets the value of the caseSensitivityType property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link CaseSensitivityType}
    */
-  public String getCaseSensitivityType() {
+  public CaseSensitivityType getCaseSensitivityType() {
     if (caseSensitivityType == null) {
-      return "everything-case-sensitive";
+      return null;
     } else {
-      return caseSensitivityType;
+      return CaseSensitivityType.fromString(caseSensitivityType);
     }
   }
 
   /**
    * Sets the value of the caseSensitivityType property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * case-sensitivity-type attribute value
    */
   public Principal setCaseSensitivityType(String value) {
-    this.caseSensitivityType = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.caseSensitivityType = null;
+    } else {
+      setCaseSensitivityType(CaseSensitivityType.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the caseSensitivityType property.
+   *
+   * @param value allowed object is {@link CaseSensitivityType} or null
+   * @return this object
+   */
+  public Principal setCaseSensitivityType(CaseSensitivityType value) {
+    if (value == null) {
+      this.caseSensitivityType = null;
+    } else {
+      this.caseSensitivityType = value.toString();
+    }
     return this;
   }
 
   /**
    * Gets the value of the principalType property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link PrincipalType}
    */
-  public String getPrincipalType() {
-    return principalType;
+  public PrincipalType getPrincipalType() {
+    if (principalType == null) {
+      return null;
+    }
+    return PrincipalType.fromString(this.principalType);
   }
 
   /**
    * Sets the value of the principalType property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * principal-type attribute value
    */
   public Principal setPrincipalType(String value) {
-    this.principalType = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.principalType = null;
+    } else {
+      setPrincipalType(PrincipalType.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the principalType property.
+   *
+   * @param value allowed object is {@link PrincipalType} or null
+   * @return this object
+   */
+  public Principal setPrincipalType(PrincipalType value) {
+    if (value == null) {
+      this.principalType = null;
+    } else {
+      this.principalType = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Record.java
+++ b/src/com/google/enterprise/gsafeed/Record.java
@@ -14,18 +14,18 @@
 
 package com.google.enterprise.gsafeed;
 
-import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -46,8 +46,7 @@ public class Record {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String displayurl;
   @XmlAttribute(name = "action")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String action;
+  protected Action action;
   @XmlAttribute(name = "mimetype", required = true)
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String mimetype;
@@ -55,11 +54,9 @@ public class Record {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String lastModified;
   @XmlAttribute(name = "lock")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String lock;
+  protected Boolean lock;
   @XmlAttribute(name = "authmethod")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String authmethod;
+  protected AuthMethod authmethod;
   @XmlAttribute(name = "feedrank")
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String feedrank;
@@ -67,21 +64,22 @@ public class Record {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String pagerank;
   @XmlAttribute(name = "crawl-immediately")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String crawlImmediately;
+  protected Boolean crawlImmediately;
   @XmlAttribute(name = "crawl-once")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String crawlOnce;
+  protected Boolean crawlOnce;
   @XmlAttribute(name = "scoring")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String scoring;
+  protected Scoring scoring;
   protected Acl acl;
   protected List<Metadata> metadata;
   protected List<Content> content;
 
   /** Action types. */
+  @XmlType(name = "record-action")
+  @XmlEnum(String.class)
   public static enum Action {
+    @XmlEnumValue("add")
     ADD("add"),
+    @XmlEnumValue("delete")
     DELETE("delete");
 
     private String xmlValue;
@@ -96,22 +94,27 @@ public class Record {
     }
 
     public static Action fromString(String value) {
-      if (value.equals("add")) {
-        return ADD;
-      }
-      if (value.equals("delete")) {
-          return DELETE;
+      for (Action action : Action.values()) {
+        if (action.xmlValue.equals(value)) {
+          return action;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   }
 
   /** Auth methods. */
+  @XmlEnum(String.class)
   public enum AuthMethod {
+    @XmlEnumValue("none")
     NONE("none"),
+    @XmlEnumValue("httpbasic")
     HTTPBASIC("httpbasic"),
+    @XmlEnumValue("ntlm")
     NTLM("ntlm"),
+    @XmlEnumValue("httpsso")
     HTTPSSO("httpsso"),
+    @XmlEnumValue("negotiate")
     NEGOTIATE("negotiate");
 
     private String xmlValue;
@@ -126,28 +129,21 @@ public class Record {
     }
 
     public static AuthMethod fromString(String value) {
-      if (value.equals("none")) {
-        return NONE;
-      }
-      if (value.equals("httpbasic")) {
-        return HTTPBASIC;
-      }
-      if (value.equals("ntlm")) {
-        return NTLM;
-      }
-      if (value.equals("httpsso")) {
-        return HTTPSSO;
-      }
-      if (value.equals("negotiate")) {
-        return NEGOTIATE;
+      for (AuthMethod authmethod : AuthMethod.values()) {
+        if (authmethod.xmlValue.equals(value)) {
+          return authmethod;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   };
 
   /** Scoring values. */
+  @XmlEnum(String.class)
   public enum Scoring {
+    @XmlEnumValue("content")
     CONTENT("content"),
+    @XmlEnumValue("web")
     WEB("web");
 
     private String xmlValue;
@@ -162,11 +158,10 @@ public class Record {
     }
 
     public static Scoring fromString(String value) {
-      if (value.equals("content")) {
-        return CONTENT;
-      }
-      if (value.equals("web")) {
-        return WEB;
+      for (Scoring scoring : Scoring.values()) {
+        if (scoring.xmlValue.equals(value)) {
+          return scoring;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -218,28 +213,7 @@ public class Record {
    * @return possible object is {@link Action}
    */
   public Action getAction() {
-    if (action == null) {
-      return null;
-    } else {
-      return Action.fromString(action);
-    }
-  }
-
-  /**
-   * Sets the value of the action property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * action attribute value
-   */
-  public Record setAction(String value) {
-    if (value == null) {
-      this.action = null;
-    } else {
-      setAction(Action.fromString(value));
-    }
-    return this;
+    return action;
   }
 
   /**
@@ -249,11 +223,7 @@ public class Record {
    * @return this object
    */
   public Record setAction(Action value) {
-    if (value == null) {
-      this.action = null;
-    } else {
-      this.action = value.toString();
-    }
+    this.action = value;
     return this;
   }
 
@@ -300,31 +270,20 @@ public class Record {
   /**
    * Gets the value of the lock property.
    *
-   * @return possible object is {@link boolean}
+   * @return possible object is {@link Boolean}
    */
-  public boolean getLock() {
-    return Boolean.valueOf(lock);
+  public Boolean getLock() {
+    return lock;
   }
 
   /**
    * Sets the value of the lock property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Boolean}
    * @return this object
    */
-  public Record setLock(String value) {
-    this.lock = Boolean.valueOf(value).toString();
-    return this;
-  }
-
-  /**
-   * Sets the value of the lock property.
-   *
-   * @param value allowed object is {@link boolean}
-   * @return this object
-   */
-  public Record setLock(boolean value) {
-    this.lock = Boolean.toString(value);
+  public Record setLock(Boolean value) {
+    this.lock = value;
     return this;
   }
 
@@ -334,28 +293,7 @@ public class Record {
    * @return possible object is {@link AuthMethod}
    */
   public AuthMethod getAuthmethod() {
-    if (authmethod == null) {
-      return null;
-    } else {
-      return AuthMethod.fromString(authmethod);
-    }
-  }
-
-  /**
-   * Sets the value of the authmethod property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * auth-method attribute value
-   */
-  public Record setAuthmethod(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.authmethod = null;
-    } else {
-      setAuthmethod(AuthMethod.fromString(value));
-    }
-    return this;
+    return authmethod;
   }
 
   /**
@@ -365,11 +303,7 @@ public class Record {
    * @return this object
    */
   public Record setAuthmethod(AuthMethod value) {
-    if (value == null) {
-      this.authmethod = null;
-    } else {
-      this.authmethod = value.toString();
-    }
+    this.authmethod = value;
     return this;
   }
 
@@ -416,62 +350,40 @@ public class Record {
   /**
    * Gets the value of the crawlImmediately property.
    *
-   * @return possible object is {@link boolean}
+   * @return possible object is {@link Boolean}
    */
-  public boolean getCrawlImmediately() {
-    return Boolean.valueOf(crawlImmediately);
+  public Boolean getCrawlImmediately() {
+    return crawlImmediately;
   }
 
   /**
    * Sets the value of the crawlImmediately property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Boolean} or null
    * @return this object
    */
-  public Record setCrawlImmediately(String value) {
-    this.crawlImmediately = Boolean.valueOf(value).toString();
-    return this;
-  }
-
-  /**
-   * Sets the value of the crawlImmediately property.
-   *
-   * @param value allowed object is {@link boolean}
-   * @return this object
-   */
-  public Record setCrawlImmediately(boolean value) {
-    this.crawlImmediately = Boolean.toString(value);
+  public Record setCrawlImmediately(Boolean value) {
+    this.crawlImmediately = value;
     return this;
   }
 
   /**
    * Gets the value of the crawlOnce property.
    *
-   * @return possible object is {@link boolean}
+   * @return possible object is {@link Boolean}
    */
-  public boolean getCrawlOnce() {
-    return Boolean.valueOf(crawlOnce);
+  public Boolean getCrawlOnce() {
+    return crawlOnce;
   }
 
   /**
    * Sets the value of the crawlOnce property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Boolean} or null
    * @return this object
    */
-  public Record setCrawlOnce(String value) {
-    this.crawlOnce = Boolean.valueOf(value).toString();
-    return this;
-  }
-
-  /**
-   * Sets the value of the crawlOnce property.
-   *
-   * @param value allowed object is {@link boolean}
-   * @return this object
-   */
-  public Record setCrawlOnce(boolean value) {
-    this.crawlOnce = Boolean.toString(value);
+  public Record setCrawlOnce(Boolean value) {
+    this.crawlOnce = value;
     return this;
   }
 
@@ -481,42 +393,17 @@ public class Record {
    * @return possible object is {@link Scoring}
    */
   public Scoring getScoring() {
-    if (scoring == null) {
-      return null;
-    } else {
-      return Scoring.fromString(scoring);
-    }
+    return scoring;
   }
 
   /**
    * Sets the value of the scoring property.
    *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * scoring attribute value
-   */
-  public Record setScoring(String value) {
-    if (value == null) {
-      this.scoring = null;
-    } else {
-      setScoring(Scoring.fromString(value));
-    }
-    return this;
-  }
-
-  /**
-   * Sets the value of the scoring property.
-   *
-   * @param value allowed object is {@link Scorng} or null
+   * @param value allowed object is {@link Scoring} or null
    * @return this object
    */
   public Record setScoring(Scoring value) {
-    if (value == null) {
-      this.scoring = null;
-    } else {
-      this.scoring = value.toString();
-    }
+    this.scoring = value;
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Record.java
+++ b/src/com/google/enterprise/gsafeed/Record.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed;
 
+import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -78,6 +79,99 @@ public class Record {
   protected List<Metadata> metadata;
   protected List<Content> content;
 
+  /** Action types. */
+  public static enum Action {
+    ADD("add"),
+    DELETE("delete");
+
+    private String xmlValue;
+
+    private Action(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Action fromString(String value) {
+      if (value.equals("add")) {
+        return ADD;
+      }
+      if (value.equals("delete")) {
+          return DELETE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Auth methods. */
+  public enum AuthMethod {
+    NONE("none"),
+    HTTPBASIC("httpbasic"),
+    NTLM("ntlm"),
+    HTTPSSO("httpsso"),
+    NEGOTIATE("negotiate");
+
+    private String xmlValue;
+
+    private AuthMethod(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static AuthMethod fromString(String value) {
+      if (value.equals("none")) {
+        return NONE;
+      }
+      if (value.equals("httpbasic")) {
+        return HTTPBASIC;
+      }
+      if (value.equals("ntlm")) {
+        return NTLM;
+      }
+      if (value.equals("httpsso")) {
+        return HTTPSSO;
+      }
+      if (value.equals("negotiate")) {
+        return NEGOTIATE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  };
+
+  /** Scoring values. */
+  public enum Scoring {
+    CONTENT("content"),
+    WEB("web");
+
+    private String xmlValue;
+
+    private Scoring(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Scoring fromString(String value) {
+      if (value.equals("content")) {
+        return CONTENT;
+      }
+      if (value.equals("web")) {
+        return WEB;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  };
+
   /**
    * Gets the value of the url property.
    *
@@ -121,20 +215,45 @@ public class Record {
   /**
    * Gets the value of the action property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Action}
    */
-  public String getAction() {
-    return action;
+  public Action getAction() {
+    if (action == null) {
+      return null;
+    } else {
+      return Action.fromString(action);
+    }
   }
 
   /**
    * Sets the value of the action property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * action attribute value
    */
   public Record setAction(String value) {
-    this.action = value;
+    if (value == null) {
+      this.action = null;
+    } else {
+      setAction(Action.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the action property.
+   *
+   * @param value allowed object is {@link Action} or null
+   * @return this object
+   */
+  public Record setAction(Action value) {
+    if (value == null) {
+      this.action = null;
+    } else {
+      this.action = value.toString();
+    }
     return this;
   }
 
@@ -181,14 +300,10 @@ public class Record {
   /**
    * Gets the value of the lock property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link boolean}
    */
-  public String getLock() {
-    if (lock == null) {
-      return "false";
-    } else {
-      return lock;
-    }
+  public boolean getLock() {
+    return Boolean.valueOf(lock);
   }
 
   /**
@@ -198,27 +313,63 @@ public class Record {
    * @return this object
    */
   public Record setLock(String value) {
-    this.lock = value;
+    this.lock = Boolean.valueOf(value).toString();
+    return this;
+  }
+
+  /**
+   * Sets the value of the lock property.
+   *
+   * @param value allowed object is {@link boolean}
+   * @return this object
+   */
+  public Record setLock(boolean value) {
+    this.lock = Boolean.toString(value);
     return this;
   }
 
   /**
    * Gets the value of the authmethod property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link AuthMethod}
    */
-  public String getAuthmethod() {
-    return authmethod;
+  public AuthMethod getAuthmethod() {
+    if (authmethod == null) {
+      return null;
+    } else {
+      return AuthMethod.fromString(authmethod);
+    }
   }
 
   /**
    * Sets the value of the authmethod property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * auth-method attribute value
    */
   public Record setAuthmethod(String value) {
-    this.authmethod = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.authmethod = null;
+    } else {
+      setAuthmethod(AuthMethod.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the authmethod property.
+   *
+   * @param value allowed object is {@link AuthMethod} or null
+   * @return this object
+   */
+  public Record setAuthmethod(AuthMethod value) {
+    if (value == null) {
+      this.authmethod = null;
+    } else {
+      this.authmethod = value.toString();
+    }
     return this;
   }
 
@@ -265,14 +416,10 @@ public class Record {
   /**
    * Gets the value of the crawlImmediately property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link boolean}
    */
-  public String getCrawlImmediately() {
-    if (crawlImmediately == null) {
-      return "false";
-    } else {
-      return crawlImmediately;
-    }
+  public boolean getCrawlImmediately() {
+    return Boolean.valueOf(crawlImmediately);
   }
 
   /**
@@ -282,21 +429,28 @@ public class Record {
    * @return this object
    */
   public Record setCrawlImmediately(String value) {
-    this.crawlImmediately = value;
+    this.crawlImmediately = Boolean.valueOf(value).toString();
+    return this;
+  }
+
+  /**
+   * Sets the value of the crawlImmediately property.
+   *
+   * @param value allowed object is {@link boolean}
+   * @return this object
+   */
+  public Record setCrawlImmediately(boolean value) {
+    this.crawlImmediately = Boolean.toString(value);
     return this;
   }
 
   /**
    * Gets the value of the crawlOnce property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link boolean}
    */
-  public String getCrawlOnce() {
-    if (crawlOnce == null) {
-      return "false";
-    } else {
-      return crawlOnce;
-    }
+  public boolean getCrawlOnce() {
+    return Boolean.valueOf(crawlOnce);
   }
 
   /**
@@ -306,27 +460,63 @@ public class Record {
    * @return this object
    */
   public Record setCrawlOnce(String value) {
-    this.crawlOnce = value;
+    this.crawlOnce = Boolean.valueOf(value).toString();
+    return this;
+  }
+
+  /**
+   * Sets the value of the crawlOnce property.
+   *
+   * @param value allowed object is {@link boolean}
+   * @return this object
+   */
+  public Record setCrawlOnce(boolean value) {
+    this.crawlOnce = Boolean.toString(value);
     return this;
   }
 
   /**
    * Gets the value of the scoring property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Scoring}
    */
-  public String getScoring() {
-    return scoring;
+  public Scoring getScoring() {
+    if (scoring == null) {
+      return null;
+    } else {
+      return Scoring.fromString(scoring);
+    }
   }
 
   /**
    * Sets the value of the scoring property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * scoring attribute value
    */
   public Record setScoring(String value) {
-    this.scoring = value;
+    if (value == null) {
+      this.scoring = null;
+    } else {
+      setScoring(Scoring.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the scoring property.
+   *
+   * @param value allowed object is {@link Scorng} or null
+   * @return this object
+   */
+  public Record setScoring(Scoring value) {
+    if (value == null) {
+      this.scoring = null;
+    } else {
+      this.scoring = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/Record.java
+++ b/src/com/google/enterprise/gsafeed/Record.java
@@ -94,6 +94,9 @@ public class Record {
     }
 
     public static Action fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Action action : Action.values()) {
         if (action.xmlValue.equals(value)) {
           return action;
@@ -129,6 +132,9 @@ public class Record {
     }
 
     public static AuthMethod fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (AuthMethod authmethod : AuthMethod.values()) {
         if (authmethod.xmlValue.equals(value)) {
           return authmethod;
@@ -158,6 +164,9 @@ public class Record {
     }
 
     public static Scoring fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Scoring scoring : Scoring.values()) {
         if (scoring.xmlValue.equals(value)) {
           return scoring;

--- a/src/com/google/enterprise/gsafeed/XmlgroupsHelper.java
+++ b/src/com/google/enterprise/gsafeed/XmlgroupsHelper.java
@@ -19,10 +19,12 @@ import com.google.enterprise.gsafeed.groups.Xmlgroups;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.charset.Charset;
 import javax.xml.bind.JAXBException;
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -30,6 +32,7 @@ import javax.xml.parsers.ParserConfigurationException;
  * Helper for reading and creating GSA feed files.
  */
 public class XmlgroupsHelper extends FeedHelper {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
 
   public XmlgroupsHelper() throws JAXBException {
     super(Xmlgroups.class, "xmlgroups", "/groupsfeed.dtd");
@@ -57,6 +60,16 @@ public class XmlgroupsHelper extends FeedHelper {
   }
 
   /**
+   * Use the DTD to check for errors in the feed being read. The
+   * xml is assumed to be UTF-8.
+   */
+  public Xmlgroups unmarshalWithDtd(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
+    return unmarshalWithDtd(new ByteArrayInputStream(xml.getBytes(UTF_8)));
+  }
+
+  /**
    * Avoid reading the DTD. No validation will happen.
    */
   public Xmlgroups unmarshalWithoutDtd(URL url) throws JAXBException,
@@ -71,6 +84,16 @@ public class XmlgroupsHelper extends FeedHelper {
       throws JAXBException, IOException, ParserConfigurationException,
       SAXException {
     return (Xmlgroups) unmarshal(inputStream, Validation.FALSE);
+  }
+
+  /**
+   * Avoid reading the DTD. No validation will happen. The xml is
+   * assumed to be UTF-8.
+   */
+  public Xmlgroups unmarshalWithoutDtd(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
+    return unmarshalWithoutDtd(new ByteArrayInputStream(xml.getBytes(UTF_8)));
   }
 
   /**

--- a/src/com/google/enterprise/gsafeed/groups/Principal.java
+++ b/src/com/google/enterprise/gsafeed/groups/Principal.java
@@ -70,6 +70,9 @@ public class Principal {
     }
 
     public static Scope fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (Scope scope : Scope.values()) {
         if (scope.xmlValue.equals(value)) {
           return scope;
@@ -102,6 +105,9 @@ public class Principal {
     }
 
     public static CaseSensitivityType fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (CaseSensitivityType type : CaseSensitivityType.values()) {
         if (type.xmlValue.equals(value)) {
           return type;
@@ -129,6 +135,9 @@ public class Principal {
     }
 
     public static PrincipalType fromString(String value) {
+      if (value == null) {
+        return null;
+      }
       for (PrincipalType type : PrincipalType.values()) {
         if (type.xmlValue.equals(value)) {
           return type;

--- a/src/com/google/enterprise/gsafeed/groups/Principal.java
+++ b/src/com/google/enterprise/gsafeed/groups/Principal.java
@@ -14,6 +14,7 @@
 
 package com.google.enterprise.gsafeed.groups;
 
+import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -50,13 +51,96 @@ public class Principal {
   @XmlValue
   protected String value;
 
+  /** Scopes. */
+  // In this case, the enum names match the XML
+  // values. Keep the enum implementation the same as all the
+  // others for consistency.
+  public static enum Scope {
+    USER("USER"),
+    GROUP("GROUP");
+
+    private String xmlValue;
+
+    private Scope(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static Scope fromString(String value) {
+      if (value.equals("USER")) {
+        return USER;
+      }
+      if (value.equals("GROUP")) {
+        return GROUP;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Case sensitivity. */
+  // In this case, the enum names match the XML
+  // values. Keep the enum implementation the same as all the
+  // others for consistency.
+  public static enum CaseSensitivityType {
+    EVERYTHING_CASE_SENSITIVE("EVERYTHING_CASE_SENSITIVE"),
+    EVERYTHING_CASE_INSENSITIVE("EVERYTHING_CASE_INSENSITIVE");
+
+    private String xmlValue;
+
+    private CaseSensitivityType(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static CaseSensitivityType fromString(String value) {
+      if (value.equals("EVERYTHING_CASE_SENSITIVE")) {
+        return EVERYTHING_CASE_SENSITIVE;
+      }
+      if (value.equals("EVERYTHING_CASE_INSENSITIVE")) {
+        return EVERYTHING_CASE_INSENSITIVE;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
+  /** Principal type. */
+  public static enum PrincipalType {
+    UNQUALIFIED("unqualified");
+
+    private String xmlValue;
+
+    private PrincipalType(String xmlValue) {
+      this.xmlValue = xmlValue;
+    }
+
+    @Override
+    public String toString() {
+      return xmlValue;
+    }
+
+    public static PrincipalType fromString(String value) {
+      if (value.equals("unqualified")) {
+        return UNQUALIFIED;
+      }
+      throw new IllegalArgumentException(value);
+    }
+  }
+
   /**
    * Gets the value of the scope property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Scope}
    */
-  public String getScope() {
-    return scope;
+  public Scope getScope() {
+    return Scope.fromString(scope);
   }
 
   /**
@@ -64,9 +148,23 @@ public class Principal {
    *
    * @param value allowed object is {@link String}
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * scope attribute value
    */
   public Principal setScope(String value) {
-    this.scope = value;
+    // scope is required, so don't accept null
+    return setScope(Scope.fromString(value));
+  }
+
+  /**
+   * Sets the value of the scope property.
+   *
+   * @param value allowed object is {@link Scope}
+   * @return this object
+   */
+  public Principal setScope(Scope value) {
+    // scope is required, so don't accept null
+    this.scope = value.toString();
     return this;
   }
 
@@ -97,44 +195,89 @@ public class Principal {
   /**
    * Gets the value of the caseSensitivityType property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link CaseSensitivityType}
    */
-  public String getCaseSensitivityType() {
+  public CaseSensitivityType getCaseSensitivityType() {
     if (caseSensitivityType == null) {
-      return "EVERYTHING_CASE_SENSITIVE";
+      return null;
     } else {
-      return caseSensitivityType;
+      return CaseSensitivityType.fromString(caseSensitivityType);
     }
   }
 
   /**
    * Sets the value of the caseSensitivityType property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * case-sensitivity-type attribute value
    */
   public Principal setCaseSensitivityType(String value) {
-    this.caseSensitivityType = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.caseSensitivityType = null;
+    } else {
+      setCaseSensitivityType(CaseSensitivityType.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the caseSensitivityType property.
+   *
+   * @param value allowed object is {@link setCaseSensitivityType} or null
+   * @return this object
+   */
+  public Principal setCaseSensitivityType(CaseSensitivityType value) {
+    if (value == null) {
+      this.caseSensitivityType = null;
+    } else {
+      this.caseSensitivityType = value.toString();
+    }
     return this;
   }
 
   /**
    * Gets the value of the principalType property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link PrincipalType}
    */
-  public String getPrincipalType() {
-    return principalType;
+  public PrincipalType getPrincipalType() {
+    if (principalType == null) {
+      return null;
+    }
+    return PrincipalType.fromString(this.principalType);
   }
 
   /**
    * Sets the value of the principalType property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link String} or null
    * @return this object
+   * @throws IllegalArgumentException if value isn't a valid
+   * principal-type attribute value
    */
   public Principal setPrincipalType(String value) {
-    this.principalType = value;
+    if (Strings.isNullOrEmpty(value)) {
+      this.principalType = null;
+    } else {
+      setPrincipalType(PrincipalType.fromString(value));
+    }
+    return this;
+  }
+
+  /**
+   * Sets the value of the principalType property.
+   *
+   * @param value allowed object is {@link PrincipalType} or null
+   * @return this object
+   */
+  public Principal setPrincipalType(PrincipalType value) {
+    if (value == null) {
+      this.principalType = null;
+    } else {
+      this.principalType = value.toString();
+    }
     return this;
   }
 

--- a/src/com/google/enterprise/gsafeed/groups/Principal.java
+++ b/src/com/google/enterprise/gsafeed/groups/Principal.java
@@ -14,17 +14,16 @@
 
 package com.google.enterprise.gsafeed.groups;
 
-import com.google.common.base.Strings;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlEnum;
+import javax.xml.bind.annotation.XmlEnumValue;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
-import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.NormalizedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-
 
 /**
  *
@@ -37,17 +36,14 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 public class Principal {
 
   @XmlAttribute(name = "scope", required = true)
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String scope;
+  protected Scope scope;
   @XmlAttribute(name = "namespace")
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String namespace;
   @XmlAttribute(name = "case-sensitivity-type")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String caseSensitivityType;
+  protected CaseSensitivityType caseSensitivityType;
   @XmlAttribute(name = "principal-type")
-  @XmlJavaTypeAdapter(CollapsedStringAdapter.class)
-  protected String principalType;
+  protected PrincipalType principalType;
   @XmlValue
   protected String value;
 
@@ -55,8 +51,11 @@ public class Principal {
   // In this case, the enum names match the XML
   // values. Keep the enum implementation the same as all the
   // others for consistency.
+  @XmlEnum(String.class)
   public static enum Scope {
+    @XmlEnumValue("USER")
     USER("USER"),
+    @XmlEnumValue("GROUP")
     GROUP("GROUP");
 
     private String xmlValue;
@@ -71,11 +70,10 @@ public class Principal {
     }
 
     public static Scope fromString(String value) {
-      if (value.equals("USER")) {
-        return USER;
-      }
-      if (value.equals("GROUP")) {
-        return GROUP;
+      for (Scope scope : Scope.values()) {
+        if (scope.xmlValue.equals(value)) {
+          return scope;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -85,8 +83,11 @@ public class Principal {
   // In this case, the enum names match the XML
   // values. Keep the enum implementation the same as all the
   // others for consistency.
+  @XmlEnum(String.class)
   public static enum CaseSensitivityType {
+    @XmlEnumValue("EVERYTHING_CASE_SENSITIVE")
     EVERYTHING_CASE_SENSITIVE("EVERYTHING_CASE_SENSITIVE"),
+    @XmlEnumValue("EVERYTHING_CASE_INSENSITIVE")
     EVERYTHING_CASE_INSENSITIVE("EVERYTHING_CASE_INSENSITIVE");
 
     private String xmlValue;
@@ -101,18 +102,19 @@ public class Principal {
     }
 
     public static CaseSensitivityType fromString(String value) {
-      if (value.equals("EVERYTHING_CASE_SENSITIVE")) {
-        return EVERYTHING_CASE_SENSITIVE;
-      }
-      if (value.equals("EVERYTHING_CASE_INSENSITIVE")) {
-        return EVERYTHING_CASE_INSENSITIVE;
+      for (CaseSensitivityType type : CaseSensitivityType.values()) {
+        if (type.xmlValue.equals(value)) {
+          return type;
+        }
       }
       throw new IllegalArgumentException(value);
     }
   }
 
   /** Principal type. */
+  @XmlEnum(String.class)
   public static enum PrincipalType {
+    @XmlEnumValue("unqualified")
     UNQUALIFIED("unqualified");
 
     private String xmlValue;
@@ -127,8 +129,10 @@ public class Principal {
     }
 
     public static PrincipalType fromString(String value) {
-      if (value.equals("unqualified")) {
-        return UNQUALIFIED;
+      for (PrincipalType type : PrincipalType.values()) {
+        if (type.xmlValue.equals(value)) {
+          return type;
+        }
       }
       throw new IllegalArgumentException(value);
     }
@@ -140,20 +144,7 @@ public class Principal {
    * @return possible object is {@link Scope}
    */
   public Scope getScope() {
-    return Scope.fromString(scope);
-  }
-
-  /**
-   * Sets the value of the scope property.
-   *
-   * @param value allowed object is {@link String}
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * scope attribute value
-   */
-  public Principal setScope(String value) {
-    // scope is required, so don't accept null
-    return setScope(Scope.fromString(value));
+    return scope;
   }
 
   /**
@@ -163,8 +154,10 @@ public class Principal {
    * @return this object
    */
   public Principal setScope(Scope value) {
-    // scope is required, so don't accept null
-    this.scope = value.toString();
+    if (value == null) {
+      throw new IllegalArgumentException("null");
+    }
+    this.scope = value;
     return this;
   }
 
@@ -198,28 +191,7 @@ public class Principal {
    * @return possible object is {@link CaseSensitivityType}
    */
   public CaseSensitivityType getCaseSensitivityType() {
-    if (caseSensitivityType == null) {
-      return null;
-    } else {
-      return CaseSensitivityType.fromString(caseSensitivityType);
-    }
-  }
-
-  /**
-   * Sets the value of the caseSensitivityType property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * case-sensitivity-type attribute value
-   */
-  public Principal setCaseSensitivityType(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.caseSensitivityType = null;
-    } else {
-      setCaseSensitivityType(CaseSensitivityType.fromString(value));
-    }
-    return this;
+    return caseSensitivityType;
   }
 
   /**
@@ -229,11 +201,7 @@ public class Principal {
    * @return this object
    */
   public Principal setCaseSensitivityType(CaseSensitivityType value) {
-    if (value == null) {
-      this.caseSensitivityType = null;
-    } else {
-      this.caseSensitivityType = value.toString();
-    }
+    this.caseSensitivityType = value;
     return this;
   }
 
@@ -243,27 +211,7 @@ public class Principal {
    * @return possible object is {@link PrincipalType}
    */
   public PrincipalType getPrincipalType() {
-    if (principalType == null) {
-      return null;
-    }
-    return PrincipalType.fromString(this.principalType);
-  }
-
-  /**
-   * Sets the value of the principalType property.
-   *
-   * @param value allowed object is {@link String} or null
-   * @return this object
-   * @throws IllegalArgumentException if value isn't a valid
-   * principal-type attribute value
-   */
-  public Principal setPrincipalType(String value) {
-    if (Strings.isNullOrEmpty(value)) {
-      this.principalType = null;
-    } else {
-      setPrincipalType(PrincipalType.fromString(value));
-    }
-    return this;
+    return principalType;
   }
 
   /**
@@ -273,11 +221,7 @@ public class Principal {
    * @return this object
    */
   public Principal setPrincipalType(PrincipalType value) {
-    if (value == null) {
-      this.principalType = null;
-    } else {
-      this.principalType = value.toString();
-    }
+    this.principalType = value;
     return this;
   }
 

--- a/test/com/google/enterprise/gsafeed/AclTest.java
+++ b/test/com/google/enterprise/gsafeed/AclTest.java
@@ -123,10 +123,22 @@ public class AclTest {
   }
 
   @Test
-  public void testInheritanceTypeInvalid() {
+  public void testInheritanceTypeFromString() {
+    for (Acl.InheritanceType value : Acl.InheritanceType.values()) {
+      assertEquals(value, Acl.InheritanceType.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testInheritanceTypeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Acl.InheritanceType.fromString("foo");
+  }
+
+  @Test
+  public void testInheritanceTypeFromStringNull() {
+    assertEquals(null, Acl.InheritanceType.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -136,6 +148,6 @@ public class AclTest {
   }
 
   private Acl unmarshal(String value) throws Exception {
-    return (Acl) JaxbUtil.unmarshalGsafeed(value);
+    return (Acl) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/AclTest.java
+++ b/test/com/google/enterprise/gsafeed/AclTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Acl.
  */
 public class AclTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -83,65 +80,53 @@ public class AclTest {
 
   @Test
   public void testGetInheritanceTypeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Acl acl = unmarshal("<acl inheritance-type='foo'/>");
-    acl.getInheritanceType();
+    assertEquals(null, acl.getInheritanceType());
   }
 
   @Test
   public void testSetInheritanceTypeChildOverrides() {
     String expected = "<acl inheritance-type='child-overrides'/>";
-    Acl acl1 = new Acl().setInheritanceType("child-overrides");
-    Acl acl2 =
+    Acl acl =
         new Acl().setInheritanceType(Acl.InheritanceType.CHILD_OVERRIDES);
-    assertNoDiffs(expected, acl1);
-    assertNoDiffs(expected, acl2);
+    assertNoDiffs(expected, acl);
   }
 
   @Test
   public void testSetInheritanceTypeParentOverrides() {
     String expected = "<acl inheritance-type='parent-overrides'/>";
-    Acl acl1 = new Acl().setInheritanceType("parent-overrides");
-    Acl acl2 =
+    Acl acl =
         new Acl().setInheritanceType(Acl.InheritanceType.PARENT_OVERRIDES);
-    assertNoDiffs(expected, acl1);
-    assertNoDiffs(expected, acl2);
+    assertNoDiffs(expected, acl);
   }
 
   @Test
   public void testSetInheritanceTypeAndBothPermit() {
     String expected = "<acl inheritance-type='and-both-permit'/>";
-    Acl acl1 = new Acl().setInheritanceType("and-both-permit");
-    Acl acl2 =
+    Acl acl =
         new Acl().setInheritanceType(Acl.InheritanceType.AND_BOTH_PERMIT);
-    assertNoDiffs(expected, acl1);
-    assertNoDiffs(expected, acl2);
+    assertNoDiffs(expected, acl);
   }
 
   @Test
   public void testSetInheritanceTypeLeafNode() {
     String expected = "<acl inheritance-type='leaf-node'/>";
-    Acl acl1 = new Acl().setInheritanceType("leaf-node");
-    Acl acl2 = new Acl().setInheritanceType(Acl.InheritanceType.LEAF_NODE);
-    assertNoDiffs(expected, acl1);
-    assertNoDiffs(expected, acl2);
+    Acl acl = new Acl().setInheritanceType(Acl.InheritanceType.LEAF_NODE);
+    assertNoDiffs(expected, acl);
   }
 
   @Test
   public void testSetInheritanceTypeNull() {
     String expected = "<acl/>";
-    Acl acl1 = new Acl().setInheritanceType((String) null);
-    Acl acl2 = new Acl().setInheritanceType((Acl.InheritanceType) null);
-    assertNoDiffs(expected, acl1);
-    assertNoDiffs(expected, acl2);
+    Acl acl = new Acl().setInheritanceType(null);
+    assertNoDiffs(expected, acl);
   }
 
   @Test
-  public void testSetInheritanceTypeInvalid() {
+  public void testInheritanceTypeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Acl().setInheritanceType("foo");
+    Acl.InheritanceType.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/AclTest.java
+++ b/test/com/google/enterprise/gsafeed/AclTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Acl.
  */
 public class AclTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testAcl() throws Exception {
     String expected =
@@ -32,7 +41,7 @@ public class AclTest {
         + " inherit-from='12345'></acl>";
     Acl acl = new Acl()
         .setUrl("http://example.com")
-        .setInheritanceType("leaf-node")
+        .setInheritanceType(Acl.InheritanceType.LEAF_NODE)
         .setInheritFrom("12345");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -40,5 +49,108 @@ public class AclTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetInheritanceTypeChildOverrides() throws Exception {
+    Acl acl = unmarshal("<acl inheritance-type='child-overrides'/>");
+    assertEquals(Acl.InheritanceType.CHILD_OVERRIDES, acl.getInheritanceType());
+  }
+
+  @Test
+  public void testGetInheritanceTypeParentOverrides() throws Exception {
+    Acl acl = unmarshal("<acl inheritance-type='parent-overrides'/>");
+    assertEquals(Acl.InheritanceType.PARENT_OVERRIDES, acl.getInheritanceType());
+  }
+
+  @Test
+  public void testGetInheritanceTypeAndBothPermit() throws Exception {
+    Acl acl = unmarshal("<acl inheritance-type='and-both-permit'/>");
+    assertEquals(Acl.InheritanceType.AND_BOTH_PERMIT, acl.getInheritanceType());
+  }
+
+  @Test
+  public void testGetInheritanceTypeLeafNode() throws Exception {
+    Acl acl = unmarshal("<acl inheritance-type='leaf-node'/>");
+    assertEquals(Acl.InheritanceType.LEAF_NODE, acl.getInheritanceType());
+  }
+
+  @Test
+  public void testGetInheritanceTypeNotSet() throws Exception {
+    Acl acl = unmarshal("<acl/>");
+    assertEquals(null, acl.getInheritanceType());
+  }
+
+  @Test
+  public void testGetInheritanceTypeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Acl acl = unmarshal("<acl inheritance-type='foo'/>");
+    acl.getInheritanceType();
+  }
+
+  @Test
+  public void testSetInheritanceTypeChildOverrides() {
+    String expected = "<acl inheritance-type='child-overrides'/>";
+    Acl acl1 = new Acl().setInheritanceType("child-overrides");
+    Acl acl2 =
+        new Acl().setInheritanceType(Acl.InheritanceType.CHILD_OVERRIDES);
+    assertNoDiffs(expected, acl1);
+    assertNoDiffs(expected, acl2);
+  }
+
+  @Test
+  public void testSetInheritanceTypeParentOverrides() {
+    String expected = "<acl inheritance-type='parent-overrides'/>";
+    Acl acl1 = new Acl().setInheritanceType("parent-overrides");
+    Acl acl2 =
+        new Acl().setInheritanceType(Acl.InheritanceType.PARENT_OVERRIDES);
+    assertNoDiffs(expected, acl1);
+    assertNoDiffs(expected, acl2);
+  }
+
+  @Test
+  public void testSetInheritanceTypeAndBothPermit() {
+    String expected = "<acl inheritance-type='and-both-permit'/>";
+    Acl acl1 = new Acl().setInheritanceType("and-both-permit");
+    Acl acl2 =
+        new Acl().setInheritanceType(Acl.InheritanceType.AND_BOTH_PERMIT);
+    assertNoDiffs(expected, acl1);
+    assertNoDiffs(expected, acl2);
+  }
+
+  @Test
+  public void testSetInheritanceTypeLeafNode() {
+    String expected = "<acl inheritance-type='leaf-node'/>";
+    Acl acl1 = new Acl().setInheritanceType("leaf-node");
+    Acl acl2 = new Acl().setInheritanceType(Acl.InheritanceType.LEAF_NODE);
+    assertNoDiffs(expected, acl1);
+    assertNoDiffs(expected, acl2);
+  }
+
+  @Test
+  public void testSetInheritanceTypeNull() {
+    String expected = "<acl/>";
+    Acl acl1 = new Acl().setInheritanceType((String) null);
+    Acl acl2 = new Acl().setInheritanceType((Acl.InheritanceType) null);
+    assertNoDiffs(expected, acl1);
+    assertNoDiffs(expected, acl2);
+  }
+
+  @Test
+  public void testSetInheritanceTypeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Acl().setInheritanceType("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Acl unmarshal(String value) throws Exception {
+    return (Acl) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/ContentTest.java
+++ b/test/com/google/enterprise/gsafeed/ContentTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Content.
  */
 public class ContentTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -38,7 +35,7 @@ public class ContentTest {
     String expected =
         "<content encoding='base64binary'>This is the content.</content>";
     Content content = new Content()
-        .setEncoding("base64binary")
+        .setEncoding(Content.Encoding.BASE_64_BINARY)
         .setvalue("This is the content.");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -62,53 +59,44 @@ public class ContentTest {
 
   @Test
   public void testGetEncodingNotSet() throws Exception {
-    Content content = unmarshal("<content>This is the content.</content>");
+    Content content = unmarshal("<content/>");
     assertEquals(null, content.getEncoding());
   }
 
   @Test
   public void testGetEncodingInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Content content = unmarshal("<content encoding='foo'/>");
-    content.getEncoding();
+    assertEquals(null, content.getEncoding());
   }
 
   @Test
   public void testSetEncodingBase64Binary() {
     String expected = "<content encoding='base64binary'/>";
-    Content content1 = new Content().setEncoding("base64binary");
-    Content content2 =
+    Content content =
         new Content().setEncoding(Content.Encoding.BASE_64_BINARY);
-    assertNoDiffs(expected, content1);
-    assertNoDiffs(expected, content2);
+    assertNoDiffs(expected, content);
   }
 
   @Test
   public void testSetEncodingBase64Compressed() {
     String expected = "<content encoding='base64compressed'/>";
-    Content content1 = new Content().setEncoding("base64compressed");
-    Content content2 =
+    Content content =
         new Content().setEncoding(Content.Encoding.BASE_64_COMPRESSED);
-    assertNoDiffs(expected, content1);
-    assertNoDiffs(expected, content2);
+    assertNoDiffs(expected, content);
   }
 
   @Test
   public void testSetEncodingNull() {
     String expected = "<content/>";
-    Content content1 = new Content().setEncoding((String) null);
-    Content content2 =
-        new Content().setEncoding((Content.Encoding) null);
-    assertNoDiffs(expected, content1);
-    assertNoDiffs(expected, content2);
+    Content content = new Content().setEncoding(null);
+    assertNoDiffs(expected, content);
   }
 
   @Test
-  public void testSetEncodingInvalid() {
+  public void testEncodingInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Content().setEncoding("foo");
+    Content.Encoding.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/ContentTest.java
+++ b/test/com/google/enterprise/gsafeed/ContentTest.java
@@ -35,7 +35,7 @@ public class ContentTest {
     String expected =
         "<content encoding='base64binary'>This is the content.</content>";
     Content content = new Content()
-        .setEncoding(Content.Encoding.BASE_64_BINARY)
+        .setEncoding(Content.Encoding.BASE64_BINARY)
         .setvalue("This is the content.");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -48,13 +48,13 @@ public class ContentTest {
   @Test
   public void testGetEncodingBase64Binary() throws Exception {
     Content content = unmarshal("<content encoding='base64binary'/>");
-    assertEquals(Content.Encoding.BASE_64_BINARY, content.getEncoding());
+    assertEquals(Content.Encoding.BASE64_BINARY, content.getEncoding());
   }
 
   @Test
   public void testGetEncodingBase64Compressed() throws Exception {
     Content content = unmarshal("<content encoding='base64compressed'/>");
-    assertEquals(Content.Encoding.BASE_64_COMPRESSED, content.getEncoding());
+    assertEquals(Content.Encoding.BASE64_COMPRESSED, content.getEncoding());
   }
 
   @Test
@@ -73,7 +73,7 @@ public class ContentTest {
   public void testSetEncodingBase64Binary() {
     String expected = "<content encoding='base64binary'/>";
     Content content =
-        new Content().setEncoding(Content.Encoding.BASE_64_BINARY);
+        new Content().setEncoding(Content.Encoding.BASE64_BINARY);
     assertNoDiffs(expected, content);
   }
 
@@ -81,7 +81,7 @@ public class ContentTest {
   public void testSetEncodingBase64Compressed() {
     String expected = "<content encoding='base64compressed'/>";
     Content content =
-        new Content().setEncoding(Content.Encoding.BASE_64_COMPRESSED);
+        new Content().setEncoding(Content.Encoding.BASE64_COMPRESSED);
     assertNoDiffs(expected, content);
   }
 

--- a/test/com/google/enterprise/gsafeed/ContentTest.java
+++ b/test/com/google/enterprise/gsafeed/ContentTest.java
@@ -93,10 +93,22 @@ public class ContentTest {
   }
 
   @Test
-  public void testEncodingInvalid() {
+  public void testEncodingFromString() {
+    for (Content.Encoding value : Content.Encoding.values()) {
+      assertEquals(value, Content.Encoding.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testEncodingFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Content.Encoding.fromString("foo");
+  }
+
+  @Test
+  public void testEncodingFromStringNull() {
+    assertEquals(null, Content.Encoding.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -106,6 +118,6 @@ public class ContentTest {
   }
 
   private Content unmarshal(String value) throws Exception {
-    return (Content) JaxbUtil.unmarshalGsafeed(value);
+    return (Content) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/ContentTest.java
+++ b/test/com/google/enterprise/gsafeed/ContentTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Content.
  */
 public class ContentTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testContent() throws Exception {
     String expected =
@@ -37,5 +46,78 @@ public class ContentTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetEncodingBase64Binary() throws Exception {
+    Content content = unmarshal("<content encoding='base64binary'/>");
+    assertEquals(Content.Encoding.BASE_64_BINARY, content.getEncoding());
+  }
+
+  @Test
+  public void testGetEncodingBase64Compressed() throws Exception {
+    Content content = unmarshal("<content encoding='base64compressed'/>");
+    assertEquals(Content.Encoding.BASE_64_COMPRESSED, content.getEncoding());
+  }
+
+  @Test
+  public void testGetEncodingNotSet() throws Exception {
+    Content content = unmarshal("<content>This is the content.</content>");
+    assertEquals(null, content.getEncoding());
+  }
+
+  @Test
+  public void testGetEncodingInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Content content = unmarshal("<content encoding='foo'/>");
+    content.getEncoding();
+  }
+
+  @Test
+  public void testSetEncodingBase64Binary() {
+    String expected = "<content encoding='base64binary'/>";
+    Content content1 = new Content().setEncoding("base64binary");
+    Content content2 =
+        new Content().setEncoding(Content.Encoding.BASE_64_BINARY);
+    assertNoDiffs(expected, content1);
+    assertNoDiffs(expected, content2);
+  }
+
+  @Test
+  public void testSetEncodingBase64Compressed() {
+    String expected = "<content encoding='base64compressed'/>";
+    Content content1 = new Content().setEncoding("base64compressed");
+    Content content2 =
+        new Content().setEncoding(Content.Encoding.BASE_64_COMPRESSED);
+    assertNoDiffs(expected, content1);
+    assertNoDiffs(expected, content2);
+  }
+
+  @Test
+  public void testSetEncodingNull() {
+    String expected = "<content/>";
+    Content content1 = new Content().setEncoding((String) null);
+    Content content2 =
+        new Content().setEncoding((Content.Encoding) null);
+    assertNoDiffs(expected, content1);
+    assertNoDiffs(expected, content2);
+  }
+
+  @Test
+  public void testSetEncodingInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Content().setEncoding("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Content unmarshal(String value) throws Exception {
+    return (Content) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/GroupTest.java
+++ b/test/com/google/enterprise/gsafeed/GroupTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Group.
  */
 public class GroupTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testGroup() throws Exception {
     String expected =
@@ -37,5 +46,75 @@ public class GroupTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetActionAdd() throws Exception {
+    Group group = unmarshal("<group action='add'/>");
+    assertEquals(Group.Action.ADD, group.getAction());
+  }
+
+  @Test
+  public void testGetActionDelete() throws Exception {
+    Group group = unmarshal("<group action='delete'/>");
+    assertEquals(Group.Action.DELETE, group.getAction());
+  }
+
+  @Test
+  public void testGetActionNotSet() throws Exception {
+    Group group = unmarshal("<group/>");
+    assertEquals(null, group.getAction());
+  }
+
+  @Test
+  public void testGetActionInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Group group = unmarshal("<group action='foo'/>");
+    group.getAction();
+  }
+
+  @Test
+  public void testSetActionAdd() {
+    String expected = "<group action='add'/>";
+    Group group1 = new Group().setAction("add");
+    Group group2 = new Group().setAction(Group.Action.ADD);
+    assertNoDiffs(expected, group1);
+    assertNoDiffs(expected, group2);
+  }
+
+  @Test
+  public void testSetActionDelete() {
+    String expected = "<group action='delete'/>";
+    Group group1 = new Group().setAction("delete");
+    Group group2 = new Group().setAction(Group.Action.DELETE);
+    assertNoDiffs(expected, group1);
+    assertNoDiffs(expected, group2);
+  }
+
+  @Test
+  public void testSetActionNull() {
+    String expected = "<group/>";
+    Group group1 = new Group().setAction((String) null);
+    Group group2 = new Group().setAction((Group.Action) null);
+    assertNoDiffs(expected, group1);
+    assertNoDiffs(expected, group2);
+  }
+
+  @Test
+  public void testSetActionInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Group().setAction("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Group unmarshal(String value) throws Exception {
+    return (Group) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/GroupTest.java
+++ b/test/com/google/enterprise/gsafeed/GroupTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Group.
  */
 public class GroupTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -38,7 +35,7 @@ public class GroupTest {
     String expected =
         "<group action='add' feedrank='1' pagerank='1'></group>";
     Group group = new Group()
-        .setAction("add")
+        .setAction(Group.Action.ADD)
         .setFeedrank("1").setPagerank("1");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -68,44 +65,36 @@ public class GroupTest {
 
   @Test
   public void testGetActionInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Group group = unmarshal("<group action='foo'/>");
-    group.getAction();
+    assertEquals(null, group.getAction());
   }
 
   @Test
   public void testSetActionAdd() {
     String expected = "<group action='add'/>";
-    Group group1 = new Group().setAction("add");
-    Group group2 = new Group().setAction(Group.Action.ADD);
-    assertNoDiffs(expected, group1);
-    assertNoDiffs(expected, group2);
+    Group group = new Group().setAction(Group.Action.ADD);
+    assertNoDiffs(expected, group);
   }
 
   @Test
   public void testSetActionDelete() {
     String expected = "<group action='delete'/>";
-    Group group1 = new Group().setAction("delete");
-    Group group2 = new Group().setAction(Group.Action.DELETE);
-    assertNoDiffs(expected, group1);
-    assertNoDiffs(expected, group2);
+    Group group = new Group().setAction(Group.Action.DELETE);
+    assertNoDiffs(expected, group);
   }
 
   @Test
   public void testSetActionNull() {
     String expected = "<group/>";
-    Group group1 = new Group().setAction((String) null);
-    Group group2 = new Group().setAction((Group.Action) null);
-    assertNoDiffs(expected, group1);
-    assertNoDiffs(expected, group2);
+    Group group = new Group().setAction(null);
+    assertNoDiffs(expected, group);
   }
 
   @Test
-  public void testSetActionInvalid() {
+  public void testInvalidAction() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Group().setAction("foo");
+    Group.Action.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/GroupTest.java
+++ b/test/com/google/enterprise/gsafeed/GroupTest.java
@@ -91,10 +91,22 @@ public class GroupTest {
   }
 
   @Test
-  public void testInvalidAction() {
+  public void testActionFromString() {
+    for (Group.Action value : Group.Action.values()) {
+      assertEquals(value, Group.Action.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testActionFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Group.Action.fromString("foo");
+  }
+
+  @Test
+  public void testActionFromStringNull() {
+    assertEquals(null, Group.Action.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -104,6 +116,6 @@ public class GroupTest {
   }
 
   private Group unmarshal(String value) throws Exception {
-    return (Group) JaxbUtil.unmarshalGsafeed(value);
+    return (Group) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/JaxbUtil.java
+++ b/test/com/google/enterprise/gsafeed/JaxbUtil.java
@@ -24,20 +24,25 @@ import javax.xml.parsers.ParserConfigurationException;
 
 /**
  * Helper to expose FeedHelper's unmarshal method for use in the
- * groups package.
+ * groups package. Using the unmarshal method directly, with no
+ * validation, lets us unmarshal individual XML elements for
+ * testing rather than needing to construct entire
+ * gsafeed/xmlgroups documents.
  */
 public class JaxbUtil {
   private static final Charset UTF_8 = Charset.forName("UTF-8");
 
-  public static Object unmarshalGsafeed(String xml) throws JAXBException,
-      IOException, ParserConfigurationException, SAXException {
+  public static Object unmarshalGsafeedElement(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
     return new GsafeedHelper().unmarshal(
         new ByteArrayInputStream(xml.getBytes(UTF_8)),
         FeedHelper.Validation.FALSE);
   }
 
-  public static Object unmarshalXmlgroups(String xml) throws JAXBException,
-      IOException, ParserConfigurationException, SAXException {
+  public static Object unmarshalXmlgroupsElement(String xml)
+      throws JAXBException, IOException, ParserConfigurationException,
+      SAXException {
     return new XmlgroupsHelper().unmarshal(
         new ByteArrayInputStream(xml.getBytes(UTF_8)),
         FeedHelper.Validation.FALSE);

--- a/test/com/google/enterprise/gsafeed/JaxbUtil.java
+++ b/test/com/google/enterprise/gsafeed/JaxbUtil.java
@@ -1,0 +1,45 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.gsafeed;
+
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import javax.xml.bind.JAXBException;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * Helper to expose FeedHelper's unmarshal method for use in the
+ * groups package.
+ */
+public class JaxbUtil {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  public static Object unmarshalGsafeed(String xml) throws JAXBException,
+      IOException, ParserConfigurationException, SAXException {
+    return new GsafeedHelper().unmarshal(
+        new ByteArrayInputStream(xml.getBytes(UTF_8)),
+        FeedHelper.Validation.FALSE);
+  }
+
+  public static Object unmarshalXmlgroups(String xml) throws JAXBException,
+      IOException, ParserConfigurationException, SAXException {
+    return new XmlgroupsHelper().unmarshal(
+        new ByteArrayInputStream(xml.getBytes(UTF_8)),
+        FeedHelper.Validation.FALSE);
+  }
+}

--- a/test/com/google/enterprise/gsafeed/MetaTest.java
+++ b/test/com/google/enterprise/gsafeed/MetaTest.java
@@ -81,10 +81,22 @@ public class MetaTest {
   }
 
   @Test
-  public void testEncodingInvalid() {
+  public void testEncodingFromString() {
+    for (Meta.Encoding value : Meta.Encoding.values()) {
+      assertEquals(value, Meta.Encoding.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testEncodingFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Meta.Encoding.fromString("foo");
+  }
+
+  @Test
+  public void testEncodingFromStringNull() {
+    assertEquals(null, Meta.Encoding.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -94,6 +106,6 @@ public class MetaTest {
   }
 
   private Meta unmarshal(String value) throws Exception {
-    return (Meta) JaxbUtil.unmarshalGsafeed(value);
+    return (Meta) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/MetaTest.java
+++ b/test/com/google/enterprise/gsafeed/MetaTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Meta.
  */
 public class MetaTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -40,7 +37,7 @@ public class MetaTest {
         + " name='meta-name'"
         + " content='meta-content'></meta>";
     Meta meta = new Meta()
-        .setEncoding("base64binary")
+        .setEncoding(Meta.Encoding.BASE_64_BINARY)
         .setName("meta-name")
         .setContent("meta-content");
     Diff diff = DiffBuilder
@@ -65,35 +62,29 @@ public class MetaTest {
 
   @Test
   public void testGetEncodingInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Meta meta = unmarshal("<meta encoding='foo'/>");
-    meta.getEncoding();
+    assertEquals(null, meta.getEncoding());
   }
 
   @Test
   public void testSetEncodingBase64Binary() {
     String expected = "<meta encoding='base64binary'/>";
-    Meta meta1 = new Meta().setEncoding("base64binary");
-    Meta meta2 = new Meta().setEncoding(Meta.Encoding.BASE_64_BINARY);
-    assertNoDiffs(expected, meta1);
-    assertNoDiffs(expected, meta2);
+    Meta meta = new Meta().setEncoding(Meta.Encoding.BASE_64_BINARY);
+    assertNoDiffs(expected, meta);
   }
 
   @Test
   public void testSetEncodingNull() {
     String expected = "<meta/>";
-    Meta meta1 = new Meta().setEncoding((String) null);
-    Meta meta2 = new Meta().setEncoding((Meta.Encoding) null);
-    assertNoDiffs(expected, meta1);
-    assertNoDiffs(expected, meta2);
+    Meta meta = new Meta().setEncoding(null);
+    assertNoDiffs(expected, meta);
   }
 
   @Test
-  public void testSetEncodingInvalid() {
+  public void testEncodingInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Meta().setEncoding("foo");
+    Meta.Encoding.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/MetaTest.java
+++ b/test/com/google/enterprise/gsafeed/MetaTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Meta.
  */
 public class MetaTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testMeta() throws Exception {
     String expected =
@@ -40,5 +49,60 @@ public class MetaTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetEncodingBase64Binary() throws Exception {
+    Meta meta = unmarshal("<meta encoding='base64binary'/>");
+    assertEquals(Meta.Encoding.BASE_64_BINARY, meta.getEncoding());
+  }
+
+  @Test
+  public void testGetEncodingNotSet() throws Exception {
+    Meta meta = unmarshal("<meta/>");
+    assertEquals(null, meta.getEncoding());
+  }
+
+  @Test
+  public void testGetEncodingInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Meta meta = unmarshal("<meta encoding='foo'/>");
+    meta.getEncoding();
+  }
+
+  @Test
+  public void testSetEncodingBase64Binary() {
+    String expected = "<meta encoding='base64binary'/>";
+    Meta meta1 = new Meta().setEncoding("base64binary");
+    Meta meta2 = new Meta().setEncoding(Meta.Encoding.BASE_64_BINARY);
+    assertNoDiffs(expected, meta1);
+    assertNoDiffs(expected, meta2);
+  }
+
+  @Test
+  public void testSetEncodingNull() {
+    String expected = "<meta/>";
+    Meta meta1 = new Meta().setEncoding((String) null);
+    Meta meta2 = new Meta().setEncoding((Meta.Encoding) null);
+    assertNoDiffs(expected, meta1);
+    assertNoDiffs(expected, meta2);
+  }
+
+  @Test
+  public void testSetEncodingInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Meta().setEncoding("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Meta unmarshal(String value) throws Exception {
+    return (Meta) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/MetaTest.java
+++ b/test/com/google/enterprise/gsafeed/MetaTest.java
@@ -37,7 +37,7 @@ public class MetaTest {
         + " name='meta-name'"
         + " content='meta-content'></meta>";
     Meta meta = new Meta()
-        .setEncoding(Meta.Encoding.BASE_64_BINARY)
+        .setEncoding(Meta.Encoding.BASE64_BINARY)
         .setName("meta-name")
         .setContent("meta-content");
     Diff diff = DiffBuilder
@@ -51,7 +51,7 @@ public class MetaTest {
   @Test
   public void testGetEncodingBase64Binary() throws Exception {
     Meta meta = unmarshal("<meta encoding='base64binary'/>");
-    assertEquals(Meta.Encoding.BASE_64_BINARY, meta.getEncoding());
+    assertEquals(Meta.Encoding.BASE64_BINARY, meta.getEncoding());
   }
 
   @Test
@@ -69,7 +69,7 @@ public class MetaTest {
   @Test
   public void testSetEncodingBase64Binary() {
     String expected = "<meta encoding='base64binary'/>";
-    Meta meta = new Meta().setEncoding(Meta.Encoding.BASE_64_BINARY);
+    Meta meta = new Meta().setEncoding(Meta.Encoding.BASE64_BINARY);
     assertNoDiffs(expected, meta);
   }
 

--- a/test/com/google/enterprise/gsafeed/MetadataTest.java
+++ b/test/com/google/enterprise/gsafeed/MetadataTest.java
@@ -20,20 +20,17 @@ import static org.junit.Assert.assertFalse;
 import org.junit.Test;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Metadata.
  */
 public class MetadataTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Test
   public void testMetadata() throws Exception {
     String expected =
         "<metadata overwrite-acls='true'></metadata>";
     Metadata metadata = new Metadata()
-        .setOverwriteAcls("true");
+        .setOverwriteAcls(true);
     Diff diff = DiffBuilder
         .compare(expected)
         .withTest(metadata)
@@ -57,38 +54,27 @@ public class MetadataTest {
   @Test
   public void testGetOverwriteAclsUnset() throws Exception {
     Metadata metadata = unmarshal("<metadata/>");
-    assertEquals(true, metadata.getOverwriteAcls());
+    assertEquals(null, metadata.getOverwriteAcls());
   }
 
   @Test
   public void setOverwriteAclsTrue() {
     String expected = "<metadata overwrite-acls='true'/>";
-    Metadata metadata1 = new Metadata().setOverwriteAcls("true");
-    Metadata metadata2 = new Metadata().setOverwriteAcls(true);
-    assertNoDiffs(expected, metadata1);
-    assertNoDiffs(expected, metadata2);
+    Metadata metadata = new Metadata().setOverwriteAcls(true);
+    assertNoDiffs(expected, metadata);
   }
 
   @Test
   public void setOverwriteAclsFalse() {
     String expected = "<metadata overwrite-acls='false'/>";
-    Metadata metadata1 = new Metadata().setOverwriteAcls("false");
-    Metadata metadata2 = new Metadata().setOverwriteAcls(false);
-    assertNoDiffs(expected, metadata1);
-    assertNoDiffs(expected, metadata2);
+    Metadata metadata = new Metadata().setOverwriteAcls(false);
+    assertNoDiffs(expected, metadata);
   }
 
   @Test
   public void setOverwriteAclsNull() {
-    String expected = "<metadata overwrite-acls='false'/>";
+    String expected = "<metadata/>";
     Metadata metadata1 = new Metadata().setOverwriteAcls(null);
-    assertNoDiffs(expected, metadata1);
-  }
-
-  @Test
-  public void setOverwriteAclsInvalid() {
-    String expected = "<metadata overwrite-acls='false'/>";
-    Metadata metadata1 = new Metadata().setOverwriteAcls("foo");
     assertNoDiffs(expected, metadata1);
   }
 

--- a/test/com/google/enterprise/gsafeed/MetadataTest.java
+++ b/test/com/google/enterprise/gsafeed/MetadataTest.java
@@ -85,6 +85,6 @@ public class MetadataTest {
   }
 
   private Metadata unmarshal(String value) throws Exception {
-    return (Metadata) JaxbUtil.unmarshalGsafeed(value);
+    return (Metadata) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/MetadataTest.java
+++ b/test/com/google/enterprise/gsafeed/MetadataTest.java
@@ -14,16 +14,20 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Metadata.
  */
 public class MetadataTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
   @Test
   public void testMetadata() throws Exception {
     String expected =
@@ -36,5 +40,65 @@ public class MetadataTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetOverwriteAclsTrue() throws Exception {
+    Metadata metadata = unmarshal("<metadata overwrite-acls='true'/>");
+    assertEquals(true, metadata.getOverwriteAcls());
+  }
+
+  @Test
+  public void testGetOverwriteAclsFalse() throws Exception {
+    Metadata metadata = unmarshal("<metadata overwrite-acls='false'/>");
+    assertEquals(false, metadata.getOverwriteAcls());
+  }
+
+  @Test
+  public void testGetOverwriteAclsUnset() throws Exception {
+    Metadata metadata = unmarshal("<metadata/>");
+    assertEquals(true, metadata.getOverwriteAcls());
+  }
+
+  @Test
+  public void setOverwriteAclsTrue() {
+    String expected = "<metadata overwrite-acls='true'/>";
+    Metadata metadata1 = new Metadata().setOverwriteAcls("true");
+    Metadata metadata2 = new Metadata().setOverwriteAcls(true);
+    assertNoDiffs(expected, metadata1);
+    assertNoDiffs(expected, metadata2);
+  }
+
+  @Test
+  public void setOverwriteAclsFalse() {
+    String expected = "<metadata overwrite-acls='false'/>";
+    Metadata metadata1 = new Metadata().setOverwriteAcls("false");
+    Metadata metadata2 = new Metadata().setOverwriteAcls(false);
+    assertNoDiffs(expected, metadata1);
+    assertNoDiffs(expected, metadata2);
+  }
+
+  @Test
+  public void setOverwriteAclsNull() {
+    String expected = "<metadata overwrite-acls='false'/>";
+    Metadata metadata1 = new Metadata().setOverwriteAcls(null);
+    assertNoDiffs(expected, metadata1);
+  }
+
+  @Test
+  public void setOverwriteAclsInvalid() {
+    String expected = "<metadata overwrite-acls='false'/>";
+    Metadata metadata1 = new Metadata().setOverwriteAcls("foo");
+    assertNoDiffs(expected, metadata1);
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Metadata unmarshal(String value) throws Exception {
+    return (Metadata) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/PrincipalTest.java
@@ -100,10 +100,22 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testScopeInvalid() {
+  public void testScopeFromString() {
+    for (Principal.Scope value : Principal.Scope.values()) {
+      assertEquals(value, Principal.Scope.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testScopeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.Scope.fromString("foo");
+  }
+
+  @Test
+  public void testScopeFromStringNull() {
+    assertEquals(null, Principal.Scope.fromString(null));
   }
 
   @Test
@@ -152,10 +164,22 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testAccessInvalid() {
+  public void testAccessFromString() {
+    for (Principal.Access value : Principal.Access.values()) {
+      assertEquals(value, Principal.Access.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testAccessFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.Access.fromString("foo");
+  }
+
+  @Test
+  public void testAccessFromStringNull() {
+    assertEquals(null, Principal.Access.fromString(null));
   }
 
   @Test
@@ -215,10 +239,24 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testCaseSensitivityTypeInvalid() {
+  public void testCaseSensitivityTypeFromString() {
+    for (Principal.CaseSensitivityType value
+             : Principal.CaseSensitivityType.values()) {
+      assertEquals(value,
+          Principal.CaseSensitivityType.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testCaseSensitivityTypeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.CaseSensitivityType.fromString("foo");
+  }
+
+  @Test
+  public void testCaseSensitivityTypeFromStringNull() {
+    assertEquals(null, Principal.CaseSensitivityType.fromString(null));
   }
 
   @Test
@@ -257,10 +295,22 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testPrincipalTypeInvalid() {
+  public void testPrincipalTypeFromString() {
+    for (Principal.PrincipalType value : Principal.PrincipalType.values()) {
+      assertEquals(value, Principal.PrincipalType.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testPrincipalTypeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.PrincipalType.fromString("foo");
+  }
+
+  @Test
+  public void testPrincipalTypeFromStringNull() {
+    assertEquals(null, Principal.PrincipalType.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -270,6 +320,6 @@ public class PrincipalTest {
   }
 
   private Principal unmarshal(String value) throws Exception {
-    return (Principal) JaxbUtil.unmarshalGsafeed(value);
+    return (Principal) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/PrincipalTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Principal.
  */
 public class PrincipalTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -42,11 +39,12 @@ public class PrincipalTest {
         + " principal-type='unqualified'>"
         + "user@example.com</principal>";
     Principal principal = new Principal()
-        .setScope("user")
-        .setAccess("permit")
+        .setScope(Principal.Scope.USER)
+        .setAccess(Principal.Access.PERMIT)
         .setNamespace("Default")
-        .setCaseSensitivityType("everything-case-sensitive")
-        .setPrincipalType("unqualified")
+        .setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE)
+        .setPrincipalType(Principal.PrincipalType.UNQUALIFIED)
         .setvalue("user@example.com");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -70,54 +68,42 @@ public class PrincipalTest {
 
   @Test
   public void testGetScopeUnset() throws Exception {
-    thrown.expect(NullPointerException.class);
     Principal principal = unmarshal("<principal/>");
-    principal.getScope();
+    assertEquals(null, principal.getScope());
   }
 
   @Test
   public void testGetScopeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal scope='foo'/>");
-    principal.getScope();
+    assertEquals(null, principal.getScope());
   }
 
   @Test
   public void testSetScopeUser() {
     String expected = "<principal scope='user'/>";
-    Principal principal1 = new Principal().setScope("user");
-    Principal principal2 = new Principal().setScope(Principal.Scope.USER);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setScope(Principal.Scope.USER);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetScopeGroup() {
     String expected = "<principal scope='group'/>";
-    Principal principal1 = new Principal().setScope("group");
-    Principal principal2 = new Principal().setScope(Principal.Scope.GROUP);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setScope(Principal.Scope.GROUP);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetScopeNullString() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setScope((String) null);
+  public void testSetScopeNull() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("null");
+    new Principal().setScope(null);
   }
 
   @Test
-  public void testSetScopeNullEnum() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setScope((Principal.Scope) null);
-  }
-
-  @Test
-  public void testSetScopeInvalid() {
+  public void testScopeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setScope("foo");
+    Principal.Scope.fromString("foo");
   }
 
   @Test
@@ -134,54 +120,42 @@ public class PrincipalTest {
 
   @Test
   public void testGetAccessUnset() throws Exception {
-    thrown.expect(NullPointerException.class);
     Principal principal = unmarshal("<principal/>");
-    principal.getAccess();
+    assertEquals(null, principal.getAccess());
   }
 
   @Test
   public void testGetAccessInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal access='foo'/>");
-    principal.getAccess();
+    assertEquals(null, principal.getAccess());
   }
 
   @Test
   public void testSetAccessPermit() {
     String expected = "<principal access='permit'/>";
-    Principal principal1 = new Principal().setAccess("permit");
-    Principal principal2 = new Principal().setAccess(Principal.Access.PERMIT);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setAccess(Principal.Access.PERMIT);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetAccessDeny() {
     String expected = "<principal access='deny'/>";
-    Principal principal1 = new Principal().setAccess("deny");
-    Principal principal2 = new Principal().setAccess(Principal.Access.DENY);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setAccess(Principal.Access.DENY);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetAccessNullString() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setAccess((String) null);
+  public void testSetAccessNull() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("null");
+    new Principal().setAccess(null);
   }
 
   @Test
-  public void testSetAccessNullEnum() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setAccess((Principal.Access) null);
-  }
-
-  @Test
-  public void testSetAccessInvalid() {
+  public void testAccessInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setAccess("foo");
+    Principal.Access.fromString("foo");
   }
 
   @Test
@@ -207,55 +181,44 @@ public class PrincipalTest {
 
   @Test
   public void testGetCaseSensitivityTypeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
-    Principal principal = unmarshal("<principal case-sensitivity-type='foo'/>");
-    principal.getCaseSensitivityType();
+    Principal principal =
+        unmarshal("<principal case-sensitivity-type='foo'/>");
+    assertEquals(null, principal.getCaseSensitivityType());
   }
 
   @Test
   public void testSetCaseSensitivityTypeSensitive() {
     String expected =
         "<principal case-sensitivity-type='everything-case-sensitive'/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType("everything-case-sensitive");
-    Principal principal2 =
+    Principal principal =
         new Principal().setCaseSensitivityType(
             Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetCaseSensitivityTypeInsensitive() {
     String expected =
         "<principal case-sensitivity-type='everything-case-insensitive'/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType("everything-case-insensitive");
-    Principal principal2 =
+    Principal principal =
         new Principal().setCaseSensitivityType(
             Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetCaseSensitivityTypeNull() {
     String expected = "<principal/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType((String) null);
-    Principal principal2 =
-        new Principal().setCaseSensitivityType(
-            (Principal.CaseSensitivityType) null);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal =
+        new Principal().setCaseSensitivityType(null);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetCaseSensitivityTypeInvalid() {
+  public void testCaseSensitivityTypeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setCaseSensitivityType("foo");
+    Principal.CaseSensitivityType.fromString("foo");
   }
 
   @Test
@@ -274,37 +237,30 @@ public class PrincipalTest {
 
   @Test
   public void testGetPrincipalTypeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal principal-type='foo'/>");
-    principal.getPrincipalType();
+    assertEquals(null, principal.getPrincipalType());
   }
 
   @Test
   public void testSetPrincipalTypeUnqualified() {
     String expected = "<principal principal-type='unqualified'/>";
-    Principal principal1 = new Principal().setPrincipalType("unqualified");
-    Principal principal2 =
+    Principal principal =
         new Principal().setPrincipalType(Principal.PrincipalType.UNQUALIFIED);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetPrincipalTypeNull() {
     String expected = "<principal/>";
-    Principal principal1 = new Principal().setPrincipalType((String) null);
-    Principal principal2 =
-        new Principal().setPrincipalType((Principal.PrincipalType) null);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setPrincipalType(null);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetPrincipalTypeInvalid() {
+  public void testPrincipalTypeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setPrincipalType("foo");
+    Principal.PrincipalType.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/PrincipalTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Principal.
  */
 public class PrincipalTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testPrincipal() throws Exception {
     String expected =
@@ -45,5 +54,266 @@ public class PrincipalTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetScopeUser() throws Exception {
+    Principal principal = unmarshal("<principal scope='user'/>");
+    assertEquals(Principal.Scope.USER, principal.getScope());
+  }
+
+  @Test
+  public void testGetScopeGroup() throws Exception {
+    Principal principal = unmarshal("<principal scope='group'/>");
+    assertEquals(Principal.Scope.GROUP, principal.getScope());
+  }
+
+  @Test
+  public void testGetScopeUnset() throws Exception {
+    thrown.expect(NullPointerException.class);
+    Principal principal = unmarshal("<principal/>");
+    principal.getScope();
+  }
+
+  @Test
+  public void testGetScopeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal scope='foo'/>");
+    principal.getScope();
+  }
+
+  @Test
+  public void testSetScopeUser() {
+    String expected = "<principal scope='user'/>";
+    Principal principal1 = new Principal().setScope("user");
+    Principal principal2 = new Principal().setScope(Principal.Scope.USER);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetScopeGroup() {
+    String expected = "<principal scope='group'/>";
+    Principal principal1 = new Principal().setScope("group");
+    Principal principal2 = new Principal().setScope(Principal.Scope.GROUP);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetScopeNullString() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setScope((String) null);
+  }
+
+  @Test
+  public void testSetScopeNullEnum() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setScope((Principal.Scope) null);
+  }
+
+  @Test
+  public void testSetScopeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setScope("foo");
+  }
+
+  @Test
+  public void testGetAccessPermit() throws Exception {
+    Principal principal = unmarshal("<principal access='permit'/>");
+    assertEquals(Principal.Access.PERMIT, principal.getAccess());
+  }
+
+  @Test
+  public void testGetAccessDeny() throws Exception {
+    Principal principal = unmarshal("<principal access='deny'/>");
+    assertEquals(Principal.Access.DENY, principal.getAccess());
+  }
+
+  @Test
+  public void testGetAccessUnset() throws Exception {
+    thrown.expect(NullPointerException.class);
+    Principal principal = unmarshal("<principal/>");
+    principal.getAccess();
+  }
+
+  @Test
+  public void testGetAccessInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal access='foo'/>");
+    principal.getAccess();
+  }
+
+  @Test
+  public void testSetAccessPermit() {
+    String expected = "<principal access='permit'/>";
+    Principal principal1 = new Principal().setAccess("permit");
+    Principal principal2 = new Principal().setAccess(Principal.Access.PERMIT);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetAccessDeny() {
+    String expected = "<principal access='deny'/>";
+    Principal principal1 = new Principal().setAccess("deny");
+    Principal principal2 = new Principal().setAccess(Principal.Access.DENY);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetAccessNullString() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setAccess((String) null);
+  }
+
+  @Test
+  public void testSetAccessNullEnum() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setAccess((Principal.Access) null);
+  }
+
+  @Test
+  public void testSetAccessInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setAccess("foo");
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeSensitive() throws Exception {
+    Principal principal = unmarshal(
+        "<principal case-sensitivity-type='everything-case-sensitive'/>");
+    assertEquals(Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE,
+        principal.getCaseSensitivityType());
+  }
+  @Test
+  public void testGetCaseSensitivityTypeInsensitive() throws Exception {
+    Principal principal = unmarshal(
+        "<principal case-sensitivity-type='everything-case-insensitive'/>");
+    assertEquals(Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE,
+        principal.getCaseSensitivityType());
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeNotSet() throws Exception {
+    Principal principal = unmarshal("<principal/>");
+    assertEquals(null, principal.getCaseSensitivityType());
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal case-sensitivity-type='foo'/>");
+    principal.getCaseSensitivityType();
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeSensitive() {
+    String expected =
+        "<principal case-sensitivity-type='everything-case-sensitive'/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType("everything-case-sensitive");
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeInsensitive() {
+    String expected =
+        "<principal case-sensitivity-type='everything-case-insensitive'/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType("everything-case-insensitive");
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeNull() {
+    String expected = "<principal/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType((String) null);
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            (Principal.CaseSensitivityType) null);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setCaseSensitivityType("foo");
+  }
+
+  @Test
+  public void testGetPrincipalTypeUnqualified() throws Exception {
+    Principal principal =
+        unmarshal("<principal principal-type='unqualified'/>");
+    assertEquals(
+        Principal.PrincipalType.UNQUALIFIED, principal.getPrincipalType());
+  }
+
+  @Test
+  public void testGetPrincipalTypeNotSet() throws Exception {
+    Principal principal = unmarshal("<principal/>");
+    assertEquals(null, principal.getPrincipalType());
+  }
+
+  @Test
+  public void testGetPrincipalTypeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal principal-type='foo'/>");
+    principal.getPrincipalType();
+  }
+
+  @Test
+  public void testSetPrincipalTypeUnqualified() {
+    String expected = "<principal principal-type='unqualified'/>";
+    Principal principal1 = new Principal().setPrincipalType("unqualified");
+    Principal principal2 =
+        new Principal().setPrincipalType(Principal.PrincipalType.UNQUALIFIED);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetPrincipalTypeNull() {
+    String expected = "<principal/>";
+    Principal principal1 = new Principal().setPrincipalType((String) null);
+    Principal principal2 =
+        new Principal().setPrincipalType((Principal.PrincipalType) null);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetPrincipalTypeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setPrincipalType("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Principal unmarshal(String value) throws Exception {
+    return (Principal) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/RecordTest.java
+++ b/test/com/google/enterprise/gsafeed/RecordTest.java
@@ -22,14 +22,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Record.
  */
 public class RecordTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -46,16 +43,16 @@ public class RecordTest {
     Record record = new Record()
         .setUrl("http://example.com")
         .setDisplayurl("http://example.com")
-        .setAction("add")
+        .setAction(Record.Action.ADD)
         .setMimetype("text/plain")
         .setLastModified("Tue, 6 Nov 2007 12:45:26 GMT")
-        .setLock("false")
-        .setAuthmethod("none")
+        .setLock(false)
+        .setAuthmethod(Record.AuthMethod.NONE)
         .setFeedrank("1")
         .setPagerank("1")
-        .setCrawlImmediately("false")
-        .setCrawlOnce("false")
-        .setScoring("content");
+        .setCrawlImmediately(false)
+        .setCrawlOnce(false)
+        .setScoring(Record.Scoring.CONTENT);
     Diff diff = DiffBuilder
         .compare(expected)
         .withTest(record)
@@ -84,44 +81,36 @@ public class RecordTest {
 
   @Test
   public void testGetActionInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Record record = unmarshal("<record action='foo'/>");
-    record.getAction();
+    assertEquals(null, record.getAction());
   }
 
   @Test
   public void testSetActionAdd() {
     String expected = "<record action='add'/>";
-    Record record1 = new Record().setAction("add");
-    Record record2 = new Record().setAction(Record.Action.ADD);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAction(Record.Action.ADD);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void testSetActionDelete() {
     String expected = "<record action='delete'/>";
-    Record record1 = new Record().setAction("delete");
-    Record record2 = new Record().setAction(Record.Action.DELETE);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAction(Record.Action.DELETE);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void testSetActionNull() {
     String expected = "<record/>";
-    Record record1 = new Record().setAction((String) null);
-    Record record2 = new Record().setAction((Record.Action) null);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAction(null);
+    assertNoDiffs(expected, record);
   }
 
   @Test
-  public void testSetActionInvalid() {
+  public void testActionInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Record().setAction("foo");
+    Record.Action.fromString("foo");
   }
 
   @Test
@@ -139,39 +128,28 @@ public class RecordTest {
   @Test
   public void testGetLockUnset() throws Exception {
     Record record = unmarshal("<record/>");
-    assertEquals(false, record.getLock());
+    assertEquals(null, record.getLock());
   }
 
   @Test
   public void setLockTrue() {
     String expected = "<record lock='true'/>";
-    Record record1 = new Record().setLock("true");
-    Record record2 = new Record().setLock(true);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setLock(true);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setLockFalse() {
     String expected = "<record lock='false'/>";
-    Record record1 = new Record().setLock("false");
-    Record record2 = new Record().setLock(false);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setLock(false);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setLockNull() {
-    String expected = "<record lock='false'/>";
-    Record record1 = new Record().setLock(null);
-    assertNoDiffs(expected, record1);
-  }
-
-  @Test
-  public void setLockInvalid() {
-    String expected = "<record lock='false'/>";
-    Record record1 = new Record().setLock("foo");
-    assertNoDiffs(expected, record1);
+    String expected = "<record/>";
+    Record record = new Record().setLock(null);
+    assertNoDiffs(expected, record);
   }
 
   @Test
@@ -212,71 +190,57 @@ public class RecordTest {
 
   @Test
   public void testGetAuthmethodInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Record record = unmarshal("<record authmethod='foo'/>");
-    record.getAuthmethod();
+    assertEquals(null, record.getAuthmethod());
   }
 
   @Test
   public void setAuthmethodNone() {
     String expected = "<record authmethod='none'/>";
-    Record record1 = new Record().setAuthmethod("none");
-    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NONE);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(Record.AuthMethod.NONE);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setAuthmethodHttpbasic() {
     String expected = "<record authmethod='httpbasic'/>";
-    Record record1 = new Record().setAuthmethod("httpbasic");
-    Record record2 = new Record().setAuthmethod(Record.AuthMethod.HTTPBASIC);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(Record.AuthMethod.HTTPBASIC);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setAuthmethodNtlm() {
     String expected = "<record authmethod='ntlm'/>";
-    Record record1 = new Record().setAuthmethod("ntlm");
-    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NTLM);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(Record.AuthMethod.NTLM);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setAuthmethodHttpsso() {
     String expected = "<record authmethod='httpsso'/>";
-    Record record1 = new Record().setAuthmethod("httpsso");
-    Record record2 = new Record().setAuthmethod(Record.AuthMethod.HTTPSSO);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(Record.AuthMethod.HTTPSSO);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setAuthmethodNegotiate() {
     String expected = "<record authmethod='negotiate'/>";
-    Record record1 = new Record().setAuthmethod("negotiate");
-    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NEGOTIATE);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(Record.AuthMethod.NEGOTIATE);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void testSetAuthmethodNull() {
     String expected = "<record/>";
-    Record record1 = new Record().setAuthmethod((String) null);
-    Record record2 = new Record().setAuthmethod((Record.AuthMethod) null);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setAuthmethod(null);
+    assertNoDiffs(expected, record);
   }
 
   @Test
-  public void testSetAuthmethodInvalid() {
+  public void testAuthmethodInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Record().setAuthmethod("foo");
+    Record.AuthMethod.fromString("foo");
   }
 
   @Test
@@ -294,38 +258,27 @@ public class RecordTest {
   @Test
   public void testGetCrawlImmediatelyUnset() throws Exception {
     Record record = unmarshal("<record/>");
-    assertEquals(false, record.getCrawlImmediately());
+    assertEquals(null, record.getCrawlImmediately());
   }
 
   @Test
   public void setCrawlImmediatelyTrue() {
     String expected = "<record crawl-immediately='true'/>";
-    Record record1 = new Record().setCrawlImmediately("true");
-    Record record2 = new Record().setCrawlImmediately(true);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setCrawlImmediately(true);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setCrawlImmediatelyFalse() {
     String expected = "<record crawl-immediately='false'/>";
-    Record record1 = new Record().setCrawlImmediately("false");
-    Record record2 = new Record().setCrawlImmediately(false);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setCrawlImmediately(false);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setCrawlImmediatelyNull() {
-    String expected = "<record crawl-immediately='false'/>";
+    String expected = "<record/>";
     Record record1 = new Record().setCrawlImmediately(null);
-    assertNoDiffs(expected, record1);
-  }
-
-  @Test
-  public void setCrawlImmediatelyInvalid() {
-    String expected = "<record crawl-immediately='false'/>";
-    Record record1 = new Record().setCrawlImmediately("foo");
     assertNoDiffs(expected, record1);
   }
 
@@ -344,39 +297,28 @@ public class RecordTest {
   @Test
   public void testGetCrawlOnceUnset() throws Exception {
     Record record = unmarshal("<record/>");
-    assertEquals(false, record.getCrawlOnce());
+    assertEquals(null, record.getCrawlOnce());
   }
 
   @Test
   public void setCrawlOnceTrue() {
     String expected = "<record crawl-once='true'/>";
-    Record record1 = new Record().setCrawlOnce("true");
-    Record record2 = new Record().setCrawlOnce(true);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setCrawlOnce(true);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setCrawlOnceFalse() {
     String expected = "<record crawl-once='false'/>";
-    Record record1 = new Record().setCrawlOnce("false");
-    Record record2 = new Record().setCrawlOnce(false);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setCrawlOnce(false);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void setCrawlOnceNull() {
-    String expected = "<record crawl-once='false'/>";
-    Record record1 = new Record().setCrawlOnce(null);
-    assertNoDiffs(expected, record1);
-  }
-
-  @Test
-  public void setCrawlOnceInvalid() {
-    String expected = "<record crawl-once='false'/>";
-    Record record1 = new Record().setCrawlOnce("foo");
-    assertNoDiffs(expected, record1);
+    String expected = "<record/>";
+    Record record = new Record().setCrawlOnce(null);
+    assertNoDiffs(expected, record);
   }
 
   @Test
@@ -399,44 +341,36 @@ public class RecordTest {
 
   @Test
   public void testGetScoringInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Record record = unmarshal("<record scoring='foo'/>");
-    record.getScoring();
+    assertEquals(null, record.getScoring());
   }
 
   @Test
   public void testSetScoringContent() {
     String expected = "<record scoring='content'/>";
-    Record record1 = new Record().setScoring("content");
-    Record record2 = new Record().setScoring(Record.Scoring.CONTENT);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setScoring(Record.Scoring.CONTENT);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void testSetScoringWeb() {
     String expected = "<record scoring='web'/>";
-    Record record1 = new Record().setScoring("web");
-    Record record2 = new Record().setScoring(Record.Scoring.WEB);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setScoring(Record.Scoring.WEB);
+    assertNoDiffs(expected, record);
   }
 
   @Test
   public void testSetScoringNull() {
     String expected = "<record/>";
-    Record record1 = new Record().setScoring((String) null);
-    Record record2 = new Record().setScoring((Record.Scoring) null);
-    assertNoDiffs(expected, record1);
-    assertNoDiffs(expected, record2);
+    Record record = new Record().setScoring(null);
+    assertNoDiffs(expected, record);
   }
 
   @Test
-  public void testSetScoringInvalid() {
+  public void testScoringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Record().setScoring("foo");
+    Record.Scoring.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/RecordTest.java
+++ b/test/com/google/enterprise/gsafeed/RecordTest.java
@@ -106,11 +106,22 @@ public class RecordTest {
     assertNoDiffs(expected, record);
   }
 
+  public void testActionFromString() {
+    for (Record.Action value : Record.Action.values()) {
+      assertEquals(value, Record.Action.fromString(value.toString()));
+    }
+  }
+
   @Test
-  public void testActionInvalid() {
+  public void testActionFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Record.Action.fromString("foo");
+  }
+
+  @Test
+  public void testActionFromStringNull() {
+    assertEquals(null, Record.Action.fromString(null));
   }
 
   @Test
@@ -236,11 +247,22 @@ public class RecordTest {
     assertNoDiffs(expected, record);
   }
 
+  public void testAuthMethodFromString() {
+    for (Record.AuthMethod value : Record.AuthMethod.values()) {
+      assertEquals(value, Record.AuthMethod.fromString(value.toString()));
+    }
+  }
+
   @Test
-  public void testAuthmethodInvalid() {
+  public void testAuthMethodFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Record.AuthMethod.fromString("foo");
+  }
+
+  @Test
+  public void testAuthMethodFromStringNull() {
+    assertEquals(null, Record.AuthMethod.fromString(null));
   }
 
   @Test
@@ -366,11 +388,64 @@ public class RecordTest {
     assertNoDiffs(expected, record);
   }
 
+  public void testScoringFromString() {
+    for (Record.Scoring value : Record.Scoring.values()) {
+      assertEquals(value, Record.Scoring.fromString(value.toString()));
+    }
+  }
+
   @Test
-  public void testScoringInvalid() {
+  public void testScoringFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Record.Scoring.fromString("foo");
+  }
+
+  @Test
+  public void testScoringFromStringNull() {
+    assertEquals(null, Record.Scoring.fromString(null));
+  }
+
+  @Test
+  public void testActionValidation() throws Exception {
+    String xml =
+        "<?xml version='1.0' encoding='utf-8'?>"
+        + "<!DOCTYPE gsafeed PUBLIC '-//Google//DTD GSA Feeds//EN' ''>"
+        + "<gsafeed>"
+        + "  <header>"
+        + "    <datasource>sample</datasource>"
+        + "    <feedtype>full</feedtype>"
+        + "  </header>"
+        + "  <group>"
+        + "   <record url='url' mimetype='mimetype' action='foo'/>"
+        + "  </group>"
+        + "</gsafeed>";
+
+    thrown.expect(org.xml.sax.SAXParseException.class);
+    thrown.expectMessage("Attribute \"action\" with value \"foo\" must"
+        + " have a value from the list \"add delete \".");
+    new GsafeedHelper().unmarshalWithDtd(xml);
+  }
+
+  @Test
+  public void testLockValidation() throws Exception {
+    String xml =
+        "<?xml version='1.0' encoding='utf-8'?>"
+        + "<!DOCTYPE gsafeed PUBLIC '-//Google//DTD GSA Feeds//EN' ''>"
+        + "<gsafeed>"
+        + "  <header>"
+        + "    <datasource>sample</datasource>"
+        + "    <feedtype>full</feedtype>"
+        + "  </header>"
+        + "  <group>"
+        + "   <record url='url' mimetype='mimetype' lock='foo'/>"
+        + "  </group>"
+        + "</gsafeed>";
+
+    thrown.expect(org.xml.sax.SAXParseException.class);
+    thrown.expectMessage("Attribute \"lock\" with value \"foo\" must"
+        + " have a value from the list \"true false \".");
+    new GsafeedHelper().unmarshalWithDtd(xml);
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -380,6 +455,6 @@ public class RecordTest {
   }
 
   private Record unmarshal(String value) throws Exception {
-    return (Record) JaxbUtil.unmarshalGsafeed(value);
+    return (Record) JaxbUtil.unmarshalGsafeedElement(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/RecordTest.java
+++ b/test/com/google/enterprise/gsafeed/RecordTest.java
@@ -14,16 +14,25 @@
 
 package com.google.enterprise.gsafeed;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Record.
  */
 public class RecordTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testRecord() throws Exception {
     String expected =
@@ -53,5 +62,390 @@ public class RecordTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetActionAdd() throws Exception {
+    Record record = unmarshal("<record action='add'/>");
+    assertEquals(Record.Action.ADD, record.getAction());
+  }
+
+  @Test
+  public void testGetActionDelete() throws Exception {
+    Record record = unmarshal("<record action='delete'/>");
+    assertEquals(Record.Action.DELETE, record.getAction());
+  }
+
+  @Test
+  public void testGetActionNotSet() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(null, record.getAction());
+  }
+
+  @Test
+  public void testGetActionInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Record record = unmarshal("<record action='foo'/>");
+    record.getAction();
+  }
+
+  @Test
+  public void testSetActionAdd() {
+    String expected = "<record action='add'/>";
+    Record record1 = new Record().setAction("add");
+    Record record2 = new Record().setAction(Record.Action.ADD);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetActionDelete() {
+    String expected = "<record action='delete'/>";
+    Record record1 = new Record().setAction("delete");
+    Record record2 = new Record().setAction(Record.Action.DELETE);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetActionNull() {
+    String expected = "<record/>";
+    Record record1 = new Record().setAction((String) null);
+    Record record2 = new Record().setAction((Record.Action) null);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetActionInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Record().setAction("foo");
+  }
+
+  @Test
+  public void testGetLockTrue() throws Exception {
+    Record record = unmarshal("<record lock='true'/>");
+    assertEquals(true, record.getLock());
+  }
+
+  @Test
+  public void testGetLockFalse() throws Exception {
+    Record record = unmarshal("<record lock='false'/>");
+    assertEquals(false, record.getLock());
+  }
+
+  @Test
+  public void testGetLockUnset() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(false, record.getLock());
+  }
+
+  @Test
+  public void setLockTrue() {
+    String expected = "<record lock='true'/>";
+    Record record1 = new Record().setLock("true");
+    Record record2 = new Record().setLock(true);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setLockFalse() {
+    String expected = "<record lock='false'/>";
+    Record record1 = new Record().setLock("false");
+    Record record2 = new Record().setLock(false);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setLockNull() {
+    String expected = "<record lock='false'/>";
+    Record record1 = new Record().setLock(null);
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void setLockInvalid() {
+    String expected = "<record lock='false'/>";
+    Record record1 = new Record().setLock("foo");
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void testGetAuthmethodNone() throws Exception {
+    Record record = unmarshal("<record authmethod='none'/>");
+    assertEquals(Record.AuthMethod.NONE, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodHttpbasic() throws Exception {
+    Record record = unmarshal("<record authmethod='httpbasic'/>");
+    assertEquals(Record.AuthMethod.HTTPBASIC, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodNtlm() throws Exception {
+    Record record = unmarshal("<record authmethod='ntlm'/>");
+    assertEquals(Record.AuthMethod.NTLM, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodHttpsso() throws Exception {
+    Record record = unmarshal("<record authmethod='httpsso'/>");
+    assertEquals(Record.AuthMethod.HTTPSSO, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodNegotiate() throws Exception {
+    Record record = unmarshal("<record authmethod='negotiate'/>");
+    assertEquals(Record.AuthMethod.NEGOTIATE, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodNotSet() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(null, record.getAuthmethod());
+  }
+
+  @Test
+  public void testGetAuthmethodInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Record record = unmarshal("<record authmethod='foo'/>");
+    record.getAuthmethod();
+  }
+
+  @Test
+  public void setAuthmethodNone() {
+    String expected = "<record authmethod='none'/>";
+    Record record1 = new Record().setAuthmethod("none");
+    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NONE);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setAuthmethodHttpbasic() {
+    String expected = "<record authmethod='httpbasic'/>";
+    Record record1 = new Record().setAuthmethod("httpbasic");
+    Record record2 = new Record().setAuthmethod(Record.AuthMethod.HTTPBASIC);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setAuthmethodNtlm() {
+    String expected = "<record authmethod='ntlm'/>";
+    Record record1 = new Record().setAuthmethod("ntlm");
+    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NTLM);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setAuthmethodHttpsso() {
+    String expected = "<record authmethod='httpsso'/>";
+    Record record1 = new Record().setAuthmethod("httpsso");
+    Record record2 = new Record().setAuthmethod(Record.AuthMethod.HTTPSSO);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setAuthmethodNegotiate() {
+    String expected = "<record authmethod='negotiate'/>";
+    Record record1 = new Record().setAuthmethod("negotiate");
+    Record record2 = new Record().setAuthmethod(Record.AuthMethod.NEGOTIATE);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetAuthmethodNull() {
+    String expected = "<record/>";
+    Record record1 = new Record().setAuthmethod((String) null);
+    Record record2 = new Record().setAuthmethod((Record.AuthMethod) null);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetAuthmethodInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Record().setAuthmethod("foo");
+  }
+
+  @Test
+  public void testGetCrawlImmediatelyTrue() throws Exception {
+    Record record = unmarshal("<record crawl-immediately='true'/>");
+    assertEquals(true, record.getCrawlImmediately());
+  }
+
+  @Test
+  public void testGetCrawlImmediatelyFalse() throws Exception {
+    Record record = unmarshal("<record crawl-immediately='false'/>");
+    assertEquals(false, record.getCrawlImmediately());
+  }
+
+  @Test
+  public void testGetCrawlImmediatelyUnset() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(false, record.getCrawlImmediately());
+  }
+
+  @Test
+  public void setCrawlImmediatelyTrue() {
+    String expected = "<record crawl-immediately='true'/>";
+    Record record1 = new Record().setCrawlImmediately("true");
+    Record record2 = new Record().setCrawlImmediately(true);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setCrawlImmediatelyFalse() {
+    String expected = "<record crawl-immediately='false'/>";
+    Record record1 = new Record().setCrawlImmediately("false");
+    Record record2 = new Record().setCrawlImmediately(false);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setCrawlImmediatelyNull() {
+    String expected = "<record crawl-immediately='false'/>";
+    Record record1 = new Record().setCrawlImmediately(null);
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void setCrawlImmediatelyInvalid() {
+    String expected = "<record crawl-immediately='false'/>";
+    Record record1 = new Record().setCrawlImmediately("foo");
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void testGetCrawlOnceTrue() throws Exception {
+    Record record = unmarshal("<record crawl-once='true'/>");
+    assertEquals(true, record.getCrawlOnce());
+  }
+
+  @Test
+  public void testGetCrawlOnceFalse() throws Exception {
+    Record record = unmarshal("<record crawl-once='false'/>");
+    assertEquals(false, record.getCrawlOnce());
+  }
+
+  @Test
+  public void testGetCrawlOnceUnset() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(false, record.getCrawlOnce());
+  }
+
+  @Test
+  public void setCrawlOnceTrue() {
+    String expected = "<record crawl-once='true'/>";
+    Record record1 = new Record().setCrawlOnce("true");
+    Record record2 = new Record().setCrawlOnce(true);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setCrawlOnceFalse() {
+    String expected = "<record crawl-once='false'/>";
+    Record record1 = new Record().setCrawlOnce("false");
+    Record record2 = new Record().setCrawlOnce(false);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void setCrawlOnceNull() {
+    String expected = "<record crawl-once='false'/>";
+    Record record1 = new Record().setCrawlOnce(null);
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void setCrawlOnceInvalid() {
+    String expected = "<record crawl-once='false'/>";
+    Record record1 = new Record().setCrawlOnce("foo");
+    assertNoDiffs(expected, record1);
+  }
+
+  @Test
+  public void testGetScoringContent() throws Exception {
+    Record record = unmarshal("<record scoring='content'/>");
+    assertEquals(Record.Scoring.CONTENT, record.getScoring());
+  }
+
+  @Test
+  public void testGetScoringWeb() throws Exception {
+    Record record = unmarshal("<record scoring='web'/>");
+    assertEquals(Record.Scoring.WEB, record.getScoring());
+  }
+
+  @Test
+  public void testGetScoringNotSet() throws Exception {
+    Record record = unmarshal("<record/>");
+    assertEquals(null, record.getScoring());
+  }
+
+  @Test
+  public void testGetScoringInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Record record = unmarshal("<record scoring='foo'/>");
+    record.getScoring();
+  }
+
+  @Test
+  public void testSetScoringContent() {
+    String expected = "<record scoring='content'/>";
+    Record record1 = new Record().setScoring("content");
+    Record record2 = new Record().setScoring(Record.Scoring.CONTENT);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetScoringWeb() {
+    String expected = "<record scoring='web'/>";
+    Record record1 = new Record().setScoring("web");
+    Record record2 = new Record().setScoring(Record.Scoring.WEB);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetScoringNull() {
+    String expected = "<record/>";
+    Record record1 = new Record().setScoring((String) null);
+    Record record2 = new Record().setScoring((Record.Scoring) null);
+    assertNoDiffs(expected, record1);
+    assertNoDiffs(expected, record2);
+  }
+
+  @Test
+  public void testSetScoringInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Record().setScoring("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Record unmarshal(String value) throws Exception {
+    return (Record) JaxbUtil.unmarshalGsafeed(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
@@ -18,19 +18,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 import com.google.enterprise.gsafeed.JaxbUtil;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
-import java.nio.charset.Charset;
 
 /**
  * Test Principal.
  */
 public class PrincipalTest {
-  private static final Charset UTF_8 = Charset.forName("UTF-8");
-
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
@@ -42,10 +40,11 @@ public class PrincipalTest {
         + " case-sensitivity-type='EVERYTHING_CASE_SENSITIVE'"
         + " principal-type='unqualified'>user@example.com</principal>";
     Principal principal = new Principal()
-        .setScope("USER")
+        .setScope(Principal.Scope.USER)
         .setNamespace("Default")
-        .setCaseSensitivityType("EVERYTHING_CASE_SENSITIVE")
-        .setPrincipalType("unqualified")
+        .setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE)
+        .setPrincipalType(Principal.PrincipalType.UNQUALIFIED)
         .setvalue("user@example.com");
     Diff diff = DiffBuilder
         .compare(expected)
@@ -56,55 +55,55 @@ public class PrincipalTest {
   }
 
   @Test
+  public void testGetScopeUser() throws Exception {
+    Principal principal = unmarshal("<principal scope='USER'/>");
+    assertEquals(Principal.Scope.USER, principal.getScope());
+  }
+
+  @Test
+  public void testGetScopeGroup() throws Exception {
+    Principal principal = unmarshal("<principal scope='GROUP'/>");
+    assertEquals(Principal.Scope.GROUP, principal.getScope());
+  }
+
+  @Test
   public void testGetScopeUnset() throws Exception {
-    thrown.expect(NullPointerException.class);
     Principal principal = unmarshal("<principal/>");
-    principal.getScope();
+    assertEquals(null, principal.getScope());
   }
 
   @Test
   public void testGetScopeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal scope='foo'/>");
-    principal.getScope();
+    assertEquals(null, principal.getScope());
   }
 
   @Test
   public void testSetScopeUser() {
     String expected = "<principal scope='USER'/>";
-    Principal principal1 = new Principal().setScope("USER");
-    Principal principal2 = new Principal().setScope(Principal.Scope.USER);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setScope(Principal.Scope.USER);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetScopeGroup() {
     String expected = "<principal scope='GROUP'/>";
-    Principal principal1 = new Principal().setScope("GROUP");
-    Principal principal2 = new Principal().setScope(Principal.Scope.GROUP);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setScope(Principal.Scope.GROUP);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetScopeNullString() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setScope((String) null);
+  public void testSetScopeNull() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("null");
+    new Principal().setScope(null);
   }
 
   @Test
-  public void testSetScopeNullEnum() {
-    thrown.expect(NullPointerException.class);
-    new Principal().setScope((Principal.Scope) null);
-  }
-
-  @Test
-  public void testSetScopeInvalid() {
+  public void testScopeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setScope("foo");
+    Principal.Scope.fromString("foo");
   }
 
   @Test
@@ -131,55 +130,42 @@ public class PrincipalTest {
 
   @Test
   public void testGetCaseSensitivityTypeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal case-sensitivity-type='foo'/>");
-    principal.getCaseSensitivityType();
+    assertEquals(null, principal.getCaseSensitivityType());
   }
 
   @Test
   public void testSetCaseSensitivityTypeSensitive() {
     String expected =
         "<principal case-sensitivity-type='EVERYTHING_CASE_SENSITIVE'/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType("EVERYTHING_CASE_SENSITIVE");
-    Principal principal2 =
+    Principal principal =
         new Principal().setCaseSensitivityType(
             Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetCaseSensitivityTypeInsensitive() {
     String expected =
         "<principal case-sensitivity-type='EVERYTHING_CASE_INSENSITIVE'/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType("EVERYTHING_CASE_INSENSITIVE");
-    Principal principal2 =
+    Principal principal =
         new Principal().setCaseSensitivityType(
             Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetCaseSensitivityTypeNull() {
     String expected = "<principal/>";
-    Principal principal1 =
-        new Principal().setCaseSensitivityType((String) null);
-    Principal principal2 =
-        new Principal().setCaseSensitivityType(
-            (Principal.CaseSensitivityType) null);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setCaseSensitivityType(null);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetCaseSensitivityTypeInvalid() {
+  public void testCaseSensitivityTypeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setCaseSensitivityType("foo");
+    Principal.CaseSensitivityType.fromString("foo");
   }
 
   @Test
@@ -198,37 +184,30 @@ public class PrincipalTest {
 
   @Test
   public void testGetPrincipalTypeInvalid() throws Exception {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("foo");
     Principal principal = unmarshal("<principal principal-type='foo'/>");
-    principal.getPrincipalType();
+    assertEquals(null, principal.getPrincipalType());
   }
 
   @Test
   public void testSetPrincipalTypeUnqualified() {
     String expected = "<principal principal-type='unqualified'/>";
-    Principal principal1 = new Principal().setPrincipalType("unqualified");
-    Principal principal2 =
+    Principal principal =
         new Principal().setPrincipalType(Principal.PrincipalType.UNQUALIFIED);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
   public void testSetPrincipalTypeNull() {
     String expected = "<principal/>";
-    Principal principal1 = new Principal().setPrincipalType((String) null);
-    Principal principal2 =
-        new Principal().setPrincipalType((Principal.PrincipalType) null);
-    assertNoDiffs(expected, principal1);
-    assertNoDiffs(expected, principal2);
+    Principal principal = new Principal().setPrincipalType(null);
+    assertNoDiffs(expected, principal);
   }
 
   @Test
-  public void testSetPrincipalTypeInvalid() {
+  public void testPrinciaplTypeInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
-    new Principal().setPrincipalType("foo");
+    Principal.PrincipalType.fromString("foo");
   }
 
   private void assertNoDiffs(String expected, Object actual) {

--- a/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
@@ -14,16 +14,26 @@
 
 package com.google.enterprise.gsafeed.groups;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import com.google.enterprise.gsafeed.JaxbUtil;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.xmlunit.builder.DiffBuilder;
 import org.xmlunit.diff.Diff;
+import java.nio.charset.Charset;
 
 /**
  * Test Principal.
  */
 public class PrincipalTest {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void testPrincipal() throws Exception {
     String expected =
@@ -43,5 +53,191 @@ public class PrincipalTest {
         .checkForSimilar()
         .build();
     assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  @Test
+  public void testGetScopeUnset() throws Exception {
+    thrown.expect(NullPointerException.class);
+    Principal principal = unmarshal("<principal/>");
+    principal.getScope();
+  }
+
+  @Test
+  public void testGetScopeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal scope='foo'/>");
+    principal.getScope();
+  }
+
+  @Test
+  public void testSetScopeUser() {
+    String expected = "<principal scope='USER'/>";
+    Principal principal1 = new Principal().setScope("USER");
+    Principal principal2 = new Principal().setScope(Principal.Scope.USER);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetScopeGroup() {
+    String expected = "<principal scope='GROUP'/>";
+    Principal principal1 = new Principal().setScope("GROUP");
+    Principal principal2 = new Principal().setScope(Principal.Scope.GROUP);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetScopeNullString() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setScope((String) null);
+  }
+
+  @Test
+  public void testSetScopeNullEnum() {
+    thrown.expect(NullPointerException.class);
+    new Principal().setScope((Principal.Scope) null);
+  }
+
+  @Test
+  public void testSetScopeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setScope("foo");
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeSensitive() throws Exception {
+    Principal principal = unmarshal(
+        "<principal case-sensitivity-type='EVERYTHING_CASE_SENSITIVE'/>");
+    assertEquals(Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE,
+        principal.getCaseSensitivityType());
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeInsensitive() throws Exception {
+    Principal principal = unmarshal(
+        "<principal case-sensitivity-type='EVERYTHING_CASE_INSENSITIVE'/>");
+    assertEquals(Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE,
+        principal.getCaseSensitivityType());
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeNotSet() throws Exception {
+    Principal principal = unmarshal("<principal/>");
+    assertEquals(null, principal.getCaseSensitivityType());
+  }
+
+  @Test
+  public void testGetCaseSensitivityTypeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal case-sensitivity-type='foo'/>");
+    principal.getCaseSensitivityType();
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeSensitive() {
+    String expected =
+        "<principal case-sensitivity-type='EVERYTHING_CASE_SENSITIVE'/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType("EVERYTHING_CASE_SENSITIVE");
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_SENSITIVE);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeInsensitive() {
+    String expected =
+        "<principal case-sensitivity-type='EVERYTHING_CASE_INSENSITIVE'/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType("EVERYTHING_CASE_INSENSITIVE");
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            Principal.CaseSensitivityType.EVERYTHING_CASE_INSENSITIVE);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeNull() {
+    String expected = "<principal/>";
+    Principal principal1 =
+        new Principal().setCaseSensitivityType((String) null);
+    Principal principal2 =
+        new Principal().setCaseSensitivityType(
+            (Principal.CaseSensitivityType) null);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetCaseSensitivityTypeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setCaseSensitivityType("foo");
+  }
+
+  @Test
+  public void testGetPrincipalTypeUnqualified() throws Exception {
+    Principal principal =
+        unmarshal("<principal principal-type='unqualified'/>");
+    assertEquals(
+        Principal.PrincipalType.UNQUALIFIED, principal.getPrincipalType());
+  }
+
+  @Test
+  public void testGetPrincipalTypeNotSet() throws Exception {
+    Principal principal = unmarshal("<principal/>");
+    assertEquals(null, principal.getPrincipalType());
+  }
+
+  @Test
+  public void testGetPrincipalTypeInvalid() throws Exception {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    Principal principal = unmarshal("<principal principal-type='foo'/>");
+    principal.getPrincipalType();
+  }
+
+  @Test
+  public void testSetPrincipalTypeUnqualified() {
+    String expected = "<principal principal-type='unqualified'/>";
+    Principal principal1 = new Principal().setPrincipalType("unqualified");
+    Principal principal2 =
+        new Principal().setPrincipalType(Principal.PrincipalType.UNQUALIFIED);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetPrincipalTypeNull() {
+    String expected = "<principal/>";
+    Principal principal1 = new Principal().setPrincipalType((String) null);
+    Principal principal2 =
+        new Principal().setPrincipalType((Principal.PrincipalType) null);
+    assertNoDiffs(expected, principal1);
+    assertNoDiffs(expected, principal2);
+  }
+
+  @Test
+  public void testSetPrincipalTypeInvalid() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("foo");
+    new Principal().setPrincipalType("foo");
+  }
+
+  private void assertNoDiffs(String expected, Object actual) {
+    Diff diff = DiffBuilder.compare(expected).withTest(actual)
+        .checkForSimilar().build();
+    assertFalse(diff.toString(), diff.hasDifferences());
+  }
+
+  private Principal unmarshal(String value) throws Exception {
+    return (Principal) JaxbUtil.unmarshalXmlgroups(value);
   }
 }

--- a/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
+++ b/test/com/google/enterprise/gsafeed/groups/PrincipalTest.java
@@ -100,10 +100,22 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testScopeInvalid() {
+  public void testScopeFromString() {
+    for (Principal.Scope value : Principal.Scope.values()) {
+      assertEquals(value, Principal.Scope.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testScopeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.Scope.fromString("foo");
+  }
+
+  @Test
+  public void testScopeFromStringNull() {
+    assertEquals(null, Principal.Scope.fromString(null));
   }
 
   @Test
@@ -162,10 +174,24 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testCaseSensitivityTypeInvalid() {
+  public void testCaseSensitivityTypeFromString() {
+    for (Principal.CaseSensitivityType value
+             : Principal.CaseSensitivityType.values()) {
+      assertEquals(value,
+          Principal.CaseSensitivityType.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testCaseSensitivityTypeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.CaseSensitivityType.fromString("foo");
+  }
+
+  @Test
+  public void testCaseSensitivityTypeFromStringNull() {
+    assertEquals(null, Principal.CaseSensitivityType.fromString(null));
   }
 
   @Test
@@ -204,10 +230,22 @@ public class PrincipalTest {
   }
 
   @Test
-  public void testPrinciaplTypeInvalid() {
+  public void testPrincipalTypeFromString() {
+    for (Principal.PrincipalType value : Principal.PrincipalType.values()) {
+      assertEquals(value, Principal.PrincipalType.fromString(value.toString()));
+    }
+  }
+
+  @Test
+  public void testPrincipalTypeFromStringInvalid() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("foo");
     Principal.PrincipalType.fromString("foo");
+  }
+
+  @Test
+  public void testPrincipalTypeFromStringNull() {
+    assertEquals(null, Principal.PrincipalType.fromString(null));
   }
 
   private void assertNoDiffs(String expected, Object actual) {
@@ -217,6 +255,6 @@ public class PrincipalTest {
   }
 
   private Principal unmarshal(String value) throws Exception {
-    return (Principal) JaxbUtil.unmarshalXmlgroups(value);
+    return (Principal) JaxbUtil.unmarshalXmlgroupsElement(value);
   }
 }


### PR DESCRIPTION
Modify the attribute getters/setters for attributes defined in
the DTD with enumerated values. Use enums for most string values
and boolean where the values in the DTD are "true|false".

The behavior on the getters is currently to return the value of
the member variable, returning null when the value is unset
(false for boolean attributes). This is different from the
generated methods, which returned the default attribute value
as specified in the DTD even when the member variable was unset. The intent
is to model what will be present in the generated XML.

Add tests that verify that the expected enum/boolean is returned
on unmarshal and that the setters result in the correct string in
the XML.