### PR TITLE
Use Date for last-modified attribute.

### DIFF
--- a/src/com/google/enterprise/gsafeed/DateAdapter.java
+++ b/src/com/google/enterprise/gsafeed/DateAdapter.java
@@ -1,0 +1,59 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.gsafeed;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * Converts between XML string representation of dates in RFC 822
+ * format and java.util.Date objects during marshal/unmarshal.
+ */
+public class DateAdapter extends XmlAdapter<String, Date> {
+  public static final String FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z";
+
+  // Definition copied from GsaFeedFileMaker in adaptor library;
+  // format string extracted for access by other code if desired.
+  private static ThreadLocal<DateFormat> rfc822Format
+    = new ThreadLocal<DateFormat>() {
+        @Override
+        protected DateFormat initialValue() {
+          DateFormat df = new SimpleDateFormat(FORMAT, Locale.ENGLISH);
+          df.setTimeZone(TimeZone.getTimeZone("GMT"));
+          return df;
+        }
+      };
+
+  @Override
+  public String marshal(Date value) {
+    if (value == null) {
+      return null;
+    }
+    return rfc822Format.get().format(value);
+  }
+
+  @Override
+  public Date unmarshal(String value) throws ParseException {
+    if (value == null) {
+      return null;
+    }
+    return rfc822Format.get().parse(value);
+  }
+}

--- a/src/com/google/enterprise/gsafeed/DateAdapter.java
+++ b/src/com/google/enterprise/gsafeed/DateAdapter.java
@@ -26,13 +26,13 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
  * Converts between XML string representation of dates in RFC 822
  * format and java.util.Date objects during marshal/unmarshal.
  */
-public class DateAdapter extends XmlAdapter<String, Date> {
-  public static final String FORMAT = "EEE, dd MMM yyyy HH:mm:ss Z";
+class DateAdapter extends XmlAdapter<String, Date> {
+  public static final String FORMAT = "EEE, dd MMM yyyy HH:mm:ss z";
 
   // Definition copied from GsaFeedFileMaker in adaptor library;
   // format string extracted for access by other code if desired.
-  private static ThreadLocal<DateFormat> rfc822Format
-    = new ThreadLocal<DateFormat>() {
+  private static final ThreadLocal<DateFormat> rfc822Format =
+      new ThreadLocal<DateFormat>() {
         @Override
         protected DateFormat initialValue() {
           DateFormat df = new SimpleDateFormat(FORMAT, Locale.ENGLISH);

--- a/src/com/google/enterprise/gsafeed/FeedHelper.java
+++ b/src/com/google/enterprise/gsafeed/FeedHelper.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.StringReader;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
@@ -41,6 +43,8 @@ import javax.xml.parsers.SAXParserFactory;
  */
 class FeedHelper {
   private static final String PUBLIC_ID = "-//Google//DTD GSA Feeds//EN";
+  private static final Logger log =
+      Logger.getLogger(FeedHelper.class.getName());
 
   enum Validation { FALSE, TRUE }
 
@@ -104,10 +108,10 @@ class FeedHelper {
               break;
             default:
               throw new IllegalArgumentException(
-                  "Unknown severity " + event.getSeverity());
+                  "Unknown severity " + event.getSeverity()
+                  + " for " + event.getMessage());
           }
-          // TODO(aptls): find out if we want logging, System.out, ...
-          System.out.println("Validation event: "
+          log.log(Level.INFO, "Validation event: "
               + severity + " " + event.getMessage());
           return shouldContinue;
         }

--- a/src/com/google/enterprise/gsafeed/GsafeedHelper.java
+++ b/src/com/google/enterprise/gsafeed/GsafeedHelper.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.ValidationEventHandler;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
@@ -38,6 +39,10 @@ public class GsafeedHelper extends FeedHelper {
 
   public void setErrorHandler(ErrorHandler errorHandler) {
     this.errorHandler = errorHandler;
+  }
+
+  public void setValidationEventHandler(ValidationEventHandler eventHandler) {
+    this.validationEventHandler = eventHandler;
   }
 
   /**

--- a/src/com/google/enterprise/gsafeed/Record.java
+++ b/src/com/google/enterprise/gsafeed/Record.java
@@ -15,6 +15,7 @@
 package com.google.enterprise.gsafeed;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -51,8 +52,8 @@ public class Record {
   @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
   protected String mimetype;
   @XmlAttribute(name = "last-modified")
-  @XmlJavaTypeAdapter(NormalizedStringAdapter.class)
-  protected String lastModified;
+  @XmlJavaTypeAdapter(DateAdapter.class)
+  protected Date lastModified;
   @XmlAttribute(name = "lock")
   protected Boolean lock;
   @XmlAttribute(name = "authmethod")
@@ -259,19 +260,19 @@ public class Record {
   /**
    * Gets the value of the lastModified property.
    *
-   * @return possible object is {@link String}
+   * @return possible object is {@link Date}
    */
-  public String getLastModified() {
+  public Date getLastModified() {
     return lastModified;
   }
 
   /**
    * Sets the value of the lastModified property.
    *
-   * @param value allowed object is {@link String}
+   * @param value allowed object is {@link Date}
    * @return this object
    */
-  public Record setLastModified(String value) {
+  public Record setLastModified(Date value) {
     this.lastModified = value;
     return this;
   }

--- a/src/com/google/enterprise/gsafeed/XmlgroupsHelper.java
+++ b/src/com/google/enterprise/gsafeed/XmlgroupsHelper.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.Charset;
 import javax.xml.bind.JAXBException;
+import javax.xml.bind.ValidationEventHandler;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
@@ -40,6 +41,10 @@ public class XmlgroupsHelper extends FeedHelper {
 
   public void setErrorHandler(ErrorHandler errorHandler) {
     this.errorHandler = errorHandler;
+  }
+
+  public void setValidationEventHandler(ValidationEventHandler eventHandler) {
+    this.validationEventHandler = eventHandler;
   }
 
   /**

--- a/test/com/google/enterprise/gsafeed/ConsoleLogging.java
+++ b/test/com/google/enterprise/gsafeed/ConsoleLogging.java
@@ -1,0 +1,60 @@
+// Copyright 2018 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.enterprise.gsafeed;
+
+import org.junit.rules.ExternalResource;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+
+/**
+ * Helper to configure the root logger's console logging during a
+ * test. Example:
+ *
+ * <pre>
+ * @ClassRule
+ * public static ConsoleLogging logging = new ConsoleLogging(Level.OFF);
+ * </pre>
+ */
+class ConsoleLogging extends ExternalResource {
+  private Handler consoleHandler;
+  private Level prevLevel;
+  private Level testLevel;
+
+  ConsoleLogging(Level level) {
+    testLevel = level;
+    Handler[] handlers =
+        LogManager.getLogManager().getLogger("").getHandlers();
+    for (Handler handler : handlers) {
+      if (handler instanceof ConsoleHandler) {
+        consoleHandler = handler;
+        prevLevel = consoleHandler.getLevel();
+        break;
+      }
+    }
+  }
+
+  @Override
+  protected void before() {
+    consoleHandler.setLevel(testLevel);
+  }
+
+  @Override
+  protected void after() {
+    consoleHandler.setLevel(prevLevel);
+  }
+}

--- a/test/com/google/enterprise/gsafeed/GsafeedHelperTest.java
+++ b/test/com/google/enterprise/gsafeed/GsafeedHelperTest.java
@@ -200,7 +200,8 @@ public class GsafeedHelperTest {
   }
 
   @Test
-  public void testWithDtdInvalidDoc() throws Exception {
+  public void testWithDtdInvalidDoc_withValidationEventHandler()
+      throws Exception {
     thrown.expect(SAXParseException.class);
     thrown.expectMessage(
         "Element type \"invalid-element\" must be declared.");
@@ -208,7 +209,20 @@ public class GsafeedHelperTest {
   }
 
   @Test
-  public void testWithoutDtdInvalidDoc() throws Exception {
+  public void testWithDtdInvalidDoc_withoutValidationEventHandler()
+      throws Exception {
+    helper.setValidationEventHandler(null);
+    thrown.expect(SAXParseException.class);
+    thrown.expectMessage(
+        "Element type \"invalid-element\" must be declared.");
+    helper.unmarshalWithDtd(asStream(invalidFeed));
+  }
+
+  @Test
+  public void testWithoutDtdInvalidDoc()
+      throws Exception {
+    // When not validating, no ValidationEventHandler is
+    // installed and the invalid element is ignored.
     Gsafeed feed = helper.unmarshalWithoutDtd(asStream(invalidFeed));
     assertEquals("sample", feed.getHeader().getDatasource());
   }

--- a/test/com/google/enterprise/gsafeed/RecordTest.java
+++ b/test/com/google/enterprise/gsafeed/RecordTest.java
@@ -524,7 +524,8 @@ public class RecordTest {
     new GsafeedHelper().unmarshalWithDtd(feed);
   }
 
-  // Add an even more straightforward date format test here.
+  // This is an even more straightforward date format test, using
+  // the adapter directly.
   @Test
   public void testDateAdapterMarshal() throws Exception {
     GregorianCalendar cal = new GregorianCalendar(TimeZone.getTimeZone("GMT"),


### PR DESCRIPTION
Change the last-modified attribute on record elements to
marshal/unmarshal as a Date object. The conversion is done using a
custom XmlAdapter, so a ValidationEventHandler has been added when
unmarshalling using the DTD to report parse errors in the adapter.